### PR TITLE
feat: add multi-agent ModelRouter routing architecture

### DIFF
--- a/packages/coding-agent/examples/extensions/multi-agent/index.ts
+++ b/packages/coding-agent/examples/extensions/multi-agent/index.ts
@@ -1,0 +1,158 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { TaskDelegator } from "./src/orchestration/TaskDelegator.js";
+import type { ModelRouterConfig } from "./src/routing/types.js";
+
+interface DelegatorCache {
+	configPath?: string;
+	mtimeMs?: number;
+	delegator?: TaskDelegator;
+}
+
+const cache: DelegatorCache = {};
+
+function splitArgs(raw: string): string[] {
+	return raw
+		.trim()
+		.split(/\s+/)
+		.filter((value) => value.length > 0);
+}
+
+function findNearestConfigPath(cwd: string): string | undefined {
+	let current = cwd;
+	while (true) {
+		const candidate = join(current, ".pi", "multi-agent.json");
+		if (existsSync(candidate)) return candidate;
+		const parent = dirname(current);
+		if (parent === current) return undefined;
+		current = parent;
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readConfig(configPath: string | undefined): ModelRouterConfig {
+	if (!configPath) return {};
+	try {
+		const parsed = JSON.parse(readFileSync(configPath, "utf-8")) as unknown;
+		if (!isRecord(parsed)) return {};
+		return parsed as ModelRouterConfig;
+	} catch {
+		return {};
+	}
+}
+
+function formatModelLines(models: ReturnType<TaskDelegator["listModels"]>): string {
+	if (models.length === 0) return "No models found.";
+	return models.map((model) => `${model.provider}/${model.id}`).join("\n");
+}
+
+function printResolvedModel(
+	ctx: ExtensionCommandContext,
+	action: string,
+	agentName: string,
+	delegator: TaskDelegator,
+	category?: string,
+): void {
+	const strategy = delegator.resolveStrategy(agentName, category);
+	if (!strategy) {
+		console.log(`[${action}] ${agentName}: no matching model`);
+		return;
+	}
+	const tried = strategy.tried.length > 0 ? ` tried=${strategy.tried.join(",")}` : "";
+	console.log(`[${action}] ${agentName}: ${strategy.provider}/${strategy.modelId} (${strategy.source})${tried}`);
+	strategy.cleanup();
+	if (ctx.hasUI) {
+		ctx.ui.notify(`${agentName} -> ${strategy.provider}/${strategy.modelId}`, "info");
+	}
+}
+
+function getDelegator(ctx: ExtensionCommandContext): TaskDelegator {
+	const configPath = findNearestConfigPath(ctx.cwd);
+	const mtimeMs = configPath ? statSync(configPath).mtimeMs : undefined;
+	const needsRefresh = cache.delegator === undefined || cache.configPath !== configPath || cache.mtimeMs !== mtimeMs;
+
+	if (needsRefresh) {
+		cache.configPath = configPath;
+		cache.mtimeMs = mtimeMs;
+		cache.delegator = new TaskDelegator(ctx.modelRegistry, readConfig(configPath));
+	}
+
+	if (!cache.delegator) {
+		cache.delegator = new TaskDelegator(ctx.modelRegistry, readConfig(configPath));
+	}
+
+	return cache.delegator;
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.registerCommand("agent.list_models", {
+		description: "List all models known to ModelRouter",
+		handler: async (_args, ctx) => {
+			const delegator = getDelegator(ctx);
+			console.log(formatModelLines(delegator.listModels()));
+		},
+	});
+
+	pi.registerCommand("agent.list_available_models", {
+		description: "List currently available models (with credentials)",
+		handler: async (_args, ctx) => {
+			const delegator = getDelegator(ctx);
+			console.log(formatModelLines(delegator.listAvailableModels()));
+		},
+	});
+
+	pi.registerCommand("agent.get_model", {
+		description: "Resolve current model for an agent: /agent.get_model <agent> [category]",
+		handler: async (args, ctx) => {
+			const [agentName, category] = splitArgs(args);
+			if (!agentName) {
+				throw new Error("Usage: /agent.get_model <agent> [category]");
+			}
+			const delegator = getDelegator(ctx);
+			printResolvedModel(ctx, "get_model", agentName, delegator, category);
+		},
+	});
+
+	pi.registerCommand("agent.set_model", {
+		description: "Set runtime model override: /agent.set_model <agent> <provider/model>",
+		handler: async (args, ctx) => {
+			const [agentName, modelReference] = splitArgs(args);
+			if (!agentName || !modelReference) {
+				throw new Error("Usage: /agent.set_model <agent> <provider/model>");
+			}
+			const delegator = getDelegator(ctx);
+			delegator.setModel(agentName, modelReference);
+			printResolvedModel(ctx, "set_model", agentName, delegator);
+		},
+	});
+
+	pi.registerCommand("agent.set_provider", {
+		description: "Set runtime provider override: /agent.set_provider <agent> <provider>",
+		handler: async (args, ctx) => {
+			const [agentName, provider] = splitArgs(args);
+			if (!agentName || !provider) {
+				throw new Error("Usage: /agent.set_provider <agent> <provider>");
+			}
+			const delegator = getDelegator(ctx);
+			delegator.setProvider(agentName, provider);
+			printResolvedModel(ctx, "set_provider", agentName, delegator);
+		},
+	});
+
+	pi.registerCommand("agent.reset_model", {
+		description: "Clear runtime model/provider override: /agent.reset_model <agent>",
+		handler: async (args, ctx) => {
+			const [agentName] = splitArgs(args);
+			if (!agentName) {
+				throw new Error("Usage: /agent.reset_model <agent>");
+			}
+			const delegator = getDelegator(ctx);
+			delegator.resetModel(agentName);
+			printResolvedModel(ctx, "reset_model", agentName, delegator);
+		},
+	});
+}

--- a/packages/coding-agent/examples/extensions/multi-agent/src/orchestration/TaskDelegator.ts
+++ b/packages/coding-agent/examples/extensions/multi-agent/src/orchestration/TaskDelegator.ts
@@ -1,0 +1,98 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import { AgentKeyInjector } from "../routing/AgentKeyInjector.js";
+import { ModelRouter } from "../routing/ModelRouter.js";
+import type { ModelRouterConfig, ResolvedModelRoute, RuntimeModelOverride } from "../routing/types.js";
+
+type ModelRegistryView = Pick<ModelRegistry, "getAll" | "getAvailable">;
+
+export interface ResolvedDelegationStrategy extends ResolvedModelRoute {
+	provider: string;
+	modelId: string;
+	env: NodeJS.ProcessEnv;
+	cleanup: () => void;
+}
+
+export class TaskDelegator {
+	private readonly router: ModelRouter;
+	private readonly keyInjector: AgentKeyInjector;
+	private readonly runtimeOverrides = new Map<string, RuntimeModelOverride>();
+
+	constructor(
+		private readonly modelRegistry: ModelRegistryView,
+		config: ModelRouterConfig = {},
+		environment: NodeJS.ProcessEnv = process.env,
+		keyInjector?: AgentKeyInjector,
+	) {
+		this.router = new ModelRouter(config);
+		this.keyInjector = keyInjector ?? new AgentKeyInjector({ baseEnv: environment });
+	}
+
+	listModels(): Model<Api>[] {
+		return this.modelRegistry.getAll();
+	}
+
+	listAvailableModels(): Model<Api>[] {
+		return this.modelRegistry.getAvailable();
+	}
+
+	getRuntimeOverride(agentName: string): RuntimeModelOverride | undefined {
+		const override = this.runtimeOverrides.get(agentName);
+		if (!override) return undefined;
+		return { ...override };
+	}
+
+	setModel(agentName: string, modelReference: string): void {
+		this.runtimeOverrides.set(agentName, { model: modelReference });
+	}
+
+	setProvider(agentName: string, provider: string): void {
+		this.runtimeOverrides.set(agentName, { provider });
+	}
+
+	resetModel(agentName: string): void {
+		this.runtimeOverrides.delete(agentName);
+	}
+
+	getModel(agentName: string, category?: string): ResolvedModelRoute | undefined {
+		return this.router.resolveForAgent(agentName, this.modelRegistry.getAll(), {
+			category,
+			runtimeOverride: this.runtimeOverrides.get(agentName),
+		});
+	}
+
+	resolveStrategy(agentName: string, category?: string): ResolvedDelegationStrategy | undefined {
+		const route = this.getModel(agentName, category);
+		if (!route) return undefined;
+
+		const availableModelSet = new Set(
+			this.modelRegistry.getAvailable().map((model) => `${model.provider}/${model.id}`),
+		);
+		const isAvailableWithoutOverrides = availableModelSet.has(`${route.model.provider}/${route.model.id}`);
+		const providerKeyOverride = route.providerKeyOverrides[route.model.provider];
+		const hasInjectedKey =
+			providerKeyOverride?.envVar !== undefined && this.keyInjector.hasEnvValue(providerKeyOverride.envVar);
+
+		const selectedRoute =
+			isAvailableWithoutOverrides || hasInjectedKey
+				? route
+				: this.router.resolveForAgent(agentName, this.modelRegistry.getAvailable(), {
+						category,
+						runtimeOverride: this.runtimeOverrides.get(agentName),
+					});
+
+		if (!selectedRoute) return undefined;
+		return this.toStrategy(selectedRoute);
+	}
+
+	private toStrategy(route: ResolvedModelRoute): ResolvedDelegationStrategy {
+		const injection = this.keyInjector.inject(route.providerKeyOverrides);
+		return {
+			...route,
+			provider: route.model.provider,
+			modelId: route.model.id,
+			env: injection.env,
+			cleanup: injection.cleanup,
+		};
+	}
+}

--- a/packages/coding-agent/examples/extensions/multi-agent/src/routing/AgentKeyInjector.ts
+++ b/packages/coding-agent/examples/extensions/multi-agent/src/routing/AgentKeyInjector.ts
@@ -1,0 +1,141 @@
+import { copyFileSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ProviderKeyOverrides } from "./types.js";
+
+const DEFAULT_PROVIDER_ENV_VARS: Record<string, string[]> = {
+	anthropic: ["ANTHROPIC_API_KEY"],
+	openai: ["OPENAI_API_KEY"],
+	google: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+	gemini: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+	openrouter: ["OPENROUTER_API_KEY"],
+	xai: ["XAI_API_KEY"],
+	mistral: ["MISTRAL_API_KEY"],
+	deepseek: ["DEEPSEEK_API_KEY"],
+	cerebras: ["CEREBRAS_API_KEY"],
+	groq: ["GROQ_API_KEY"],
+	together: ["TOGETHER_API_KEY"],
+	perplexity: ["PERPLEXITY_API_KEY"],
+	fireworks: ["FIREWORKS_API_KEY"],
+};
+
+interface ModelsProviderConfig {
+	baseUrl?: string;
+	apiKey?: string;
+	api?: string;
+	headers?: Record<string, string>;
+	models?: unknown[];
+	modelOverrides?: Record<string, unknown>;
+}
+
+interface ModelsConfig {
+	providers: Record<string, ModelsProviderConfig>;
+}
+
+export interface AgentKeyInjectionResult {
+	env: NodeJS.ProcessEnv;
+	cleanup: () => void;
+}
+
+export interface AgentKeyInjectorOptions {
+	baseEnv?: NodeJS.ProcessEnv;
+	agentDir?: string;
+}
+
+function getDefaultAgentDir(baseEnv: NodeJS.ProcessEnv): string {
+	const configured = baseEnv.PI_CODING_AGENT_DIR;
+	if (configured && configured.trim().length > 0) {
+		return configured;
+	}
+	return join(homedir(), ".pi", "agent");
+}
+
+function getProviderKeyTargets(provider: string): string[] {
+	const mapped = DEFAULT_PROVIDER_ENV_VARS[provider];
+	if (mapped && mapped.length > 0) return mapped;
+	const normalized = provider.replace(/[^A-Za-z0-9]+/g, "_").toUpperCase();
+	return [`${normalized}_API_KEY`];
+}
+
+function readModelsConfig(path: string): ModelsConfig {
+	if (!existsSync(path)) {
+		return { providers: {} };
+	}
+
+	try {
+		const raw = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+		if (typeof raw !== "object" || raw === null) return { providers: {} };
+		const providers = (raw as { providers?: unknown }).providers;
+		if (typeof providers !== "object" || providers === null) return { providers: {} };
+		return { providers: providers as Record<string, ModelsProviderConfig> };
+	} catch {
+		return { providers: {} };
+	}
+}
+
+export class AgentKeyInjector {
+	private readonly baseEnv: NodeJS.ProcessEnv;
+	private readonly agentDir: string;
+
+	constructor(options: AgentKeyInjectorOptions = {}) {
+		this.baseEnv = { ...(options.baseEnv ?? process.env) };
+		this.agentDir = options.agentDir ?? getDefaultAgentDir(this.baseEnv);
+	}
+
+	hasEnvValue(envVar: string): boolean {
+		const value = this.baseEnv[envVar];
+		return typeof value === "string" && value.length > 0;
+	}
+
+	inject(overrides: ProviderKeyOverrides | undefined): AgentKeyInjectionResult {
+		const env: NodeJS.ProcessEnv = { ...this.baseEnv };
+		if (!overrides || Object.keys(overrides).length === 0) {
+			return { env, cleanup: () => {} };
+		}
+
+		const baseUrlOverrides: Record<string, string> = {};
+
+		for (const [provider, override] of Object.entries(overrides)) {
+			if (override.envVar && this.hasEnvValue(override.envVar)) {
+				const value = this.baseEnv[override.envVar] as string;
+				for (const targetEnvVar of getProviderKeyTargets(provider)) {
+					env[targetEnvVar] = value;
+				}
+			}
+
+			if (override.baseUrl) {
+				baseUrlOverrides[provider] = override.baseUrl;
+			}
+		}
+
+		if (Object.keys(baseUrlOverrides).length === 0) {
+			return { env, cleanup: () => {} };
+		}
+
+		const tempAgentDir = mkdtempSync(join(tmpdir(), "pi-model-router-"));
+		const modelsConfig = readModelsConfig(join(this.agentDir, "models.json"));
+		const mergedProviders: Record<string, ModelsProviderConfig> = { ...modelsConfig.providers };
+
+		for (const [provider, baseUrl] of Object.entries(baseUrlOverrides)) {
+			mergedProviders[provider] = { ...(mergedProviders[provider] ?? {}), baseUrl };
+		}
+
+		const tempModelsPath = join(tempAgentDir, "models.json");
+		writeFileSync(tempModelsPath, JSON.stringify({ providers: mergedProviders }, null, "\t"));
+
+		for (const filename of ["auth.json", "settings.json"] as const) {
+			const source = join(this.agentDir, filename);
+			if (!existsSync(source)) continue;
+			copyFileSync(source, join(tempAgentDir, filename));
+		}
+
+		env.PI_CODING_AGENT_DIR = tempAgentDir;
+
+		return {
+			env,
+			cleanup: () => {
+				rmSync(tempAgentDir, { recursive: true, force: true });
+			},
+		};
+	}
+}

--- a/packages/coding-agent/examples/extensions/multi-agent/src/routing/ModelRouter.ts
+++ b/packages/coding-agent/examples/extensions/multi-agent/src/routing/ModelRouter.ts
@@ -1,0 +1,258 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type {
+	AgentModelConfig,
+	ModelConstraints,
+	ModelRouterConfig,
+	ModelRouteSource,
+	ProviderKeyOverrides,
+	ResolvedModelRoute,
+	ResolveModelOptions,
+} from "./types.js";
+
+interface ModelCandidate {
+	type: "model";
+	value: string;
+	source: ModelRouteSource;
+}
+
+interface ProviderCandidate {
+	type: "provider";
+	value: string;
+	source: ModelRouteSource;
+}
+
+type Candidate = ModelCandidate | ProviderCandidate;
+
+interface ParsedModelReference {
+	provider?: string;
+	modelId: string;
+}
+
+function mergeConstraints(
+	categoryConstraints: ModelConstraints | undefined,
+	agentConstraints: ModelConstraints | undefined,
+): ModelConstraints | undefined {
+	if (!categoryConstraints && !agentConstraints) return undefined;
+	return {
+		...categoryConstraints,
+		...agentConstraints,
+		requiresCapabilities: agentConstraints?.requiresCapabilities ?? categoryConstraints?.requiresCapabilities,
+	};
+}
+
+function mergeProviderKeyOverrides(
+	globalOverrides: ProviderKeyOverrides | undefined,
+	categoryOverrides: ProviderKeyOverrides | undefined,
+	agentOverrides: ProviderKeyOverrides | undefined,
+): ProviderKeyOverrides {
+	const merged: ProviderKeyOverrides = {};
+	for (const layer of [globalOverrides, categoryOverrides, agentOverrides]) {
+		if (!layer) continue;
+		for (const [provider, override] of Object.entries(layer)) {
+			merged[provider] = { ...merged[provider], ...override };
+		}
+	}
+	return merged;
+}
+
+function parseModelReference(reference: string): ParsedModelReference {
+	const separator = reference.indexOf("/");
+	if (separator === -1) {
+		return { modelId: reference };
+	}
+	const provider = reference.slice(0, separator).trim();
+	const modelId = reference.slice(separator + 1).trim();
+	if (!provider || !modelId) {
+		return { modelId: reference };
+	}
+	return { provider, modelId };
+}
+
+function matchesConstraints(model: Model<Api>, constraints: ModelConstraints | undefined): boolean {
+	if (!constraints) return true;
+	if (constraints.maxInputCost !== undefined && model.cost.input > constraints.maxInputCost) return false;
+	if (constraints.maxOutputCost !== undefined && model.cost.output > constraints.maxOutputCost) return false;
+	if (constraints.minContextWindow !== undefined && model.contextWindow < constraints.minContextWindow) return false;
+	if (constraints.maxContextWindow !== undefined && model.contextWindow > constraints.maxContextWindow) return false;
+	if (constraints.requiresReasoning && !model.reasoning) return false;
+
+	if (constraints.requiresCapabilities && constraints.requiresCapabilities.length > 0) {
+		for (const capability of constraints.requiresCapabilities) {
+			if (!model.input.includes(capability)) return false;
+		}
+	}
+
+	return true;
+}
+
+function compareModelPriority(left: Model<Api>, right: Model<Api>): number {
+	const leftCost = left.cost.input + left.cost.output;
+	const rightCost = right.cost.input + right.cost.output;
+	if (leftCost !== rightCost) return leftCost - rightCost;
+	if (left.contextWindow !== right.contextWindow) return right.contextWindow - left.contextWindow;
+	return left.id.localeCompare(right.id);
+}
+
+function dedupeCandidates(candidates: Candidate[]): Candidate[] {
+	const seen = new Set<string>();
+	const deduped: Candidate[] = [];
+	for (const candidate of candidates) {
+		const key = `${candidate.type}:${candidate.value}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		deduped.push(candidate);
+	}
+	return deduped;
+}
+
+export class ModelRouter {
+	constructor(private readonly config: ModelRouterConfig = {}) {}
+
+	resolveForAgent(
+		agentName: string,
+		models: Model<Api>[],
+		options: ResolveModelOptions = {},
+	): ResolvedModelRoute | undefined {
+		const agentConfig = this.config.agents?.[agentName];
+		const categoryName = options.category ?? agentConfig?.category;
+		const categoryConfig = categoryName ? this.config.categories?.[categoryName] : undefined;
+
+		const constraints = mergeConstraints(categoryConfig?.constraints, agentConfig?.constraints);
+		const providerKeyOverrides = mergeProviderKeyOverrides(
+			this.config.providerKeys,
+			categoryConfig?.providerKeys,
+			agentConfig?.providerKeys,
+		);
+
+		const candidates = dedupeCandidates(this.buildCandidates(options.runtimeOverride, agentConfig, categoryConfig));
+		const tried: string[] = [];
+
+		for (const candidate of candidates) {
+			if (candidate.type === "model") {
+				const match = this.findModelByReference(candidate.value, models, constraints);
+				if (match) {
+					return {
+						agentName,
+						category: categoryName,
+						model: match,
+						source: candidate.source,
+						tried,
+						providerKeyOverrides,
+					};
+				}
+				tried.push(`model:${candidate.value}`);
+				continue;
+			}
+
+			const providerMatch = this.findModelByProvider(candidate.value, models, constraints);
+			if (providerMatch) {
+				return {
+					agentName,
+					category: categoryName,
+					model: providerMatch,
+					source: candidate.source,
+					tried,
+					providerKeyOverrides,
+				};
+			}
+			tried.push(`provider:${candidate.value}`);
+		}
+
+		if (this.config.lastResortModel) {
+			const lastResort = this.findModelByReference(this.config.lastResortModel, models, undefined);
+			if (lastResort) {
+				return {
+					agentName,
+					category: categoryName,
+					model: lastResort,
+					source: "last-resort-model",
+					tried,
+					providerKeyOverrides,
+				};
+			}
+			tried.push(`lastResort:${this.config.lastResortModel}`);
+		}
+
+		return undefined;
+	}
+
+	resolveForCategory(category: string, models: Model<Api>[]): ResolvedModelRoute | undefined {
+		return this.resolveForAgent(category, models, { category });
+	}
+
+	private buildCandidates(
+		runtimeOverride: ResolveModelOptions["runtimeOverride"],
+		agentConfig: AgentModelConfig | undefined,
+		categoryConfig: AgentModelConfig | undefined,
+	): Candidate[] {
+		const candidates: Candidate[] = [];
+
+		if (runtimeOverride?.model) {
+			candidates.push({ type: "model", value: runtimeOverride.model, source: "runtime-model" });
+		}
+		if (runtimeOverride?.provider) {
+			candidates.push({ type: "provider", value: runtimeOverride.provider, source: "runtime-provider" });
+		}
+
+		if (agentConfig?.model) {
+			candidates.push({ type: "model", value: agentConfig.model, source: "agent-model" });
+		}
+		for (const model of agentConfig?.modelChain ?? []) {
+			candidates.push({ type: "model", value: model, source: "agent-chain" });
+		}
+		if (agentConfig?.provider) {
+			candidates.push({ type: "provider", value: agentConfig.provider, source: "agent-provider" });
+		}
+
+		if (categoryConfig?.model) {
+			candidates.push({ type: "model", value: categoryConfig.model, source: "category-model" });
+		}
+		for (const model of categoryConfig?.modelChain ?? []) {
+			candidates.push({ type: "model", value: model, source: "category-chain" });
+		}
+		if (categoryConfig?.provider) {
+			candidates.push({ type: "provider", value: categoryConfig.provider, source: "category-provider" });
+		}
+
+		return candidates;
+	}
+
+	private findModelByReference(
+		reference: string,
+		models: Model<Api>[],
+		constraints: ModelConstraints | undefined,
+	): Model<Api> | undefined {
+		const parsed = parseModelReference(reference.trim());
+		if (!parsed.modelId) return undefined;
+
+		const byProviderAndId =
+			parsed.provider !== undefined
+				? models.filter((model) => model.provider === parsed.provider && model.id === parsed.modelId)
+				: models.filter((model) => model.id === parsed.modelId);
+		const exact = byProviderAndId
+			.filter((model) => matchesConstraints(model, constraints))
+			.sort(compareModelPriority);
+		if (exact.length > 0) return exact[0];
+
+		const byProviderAndPartial =
+			parsed.provider !== undefined
+				? models.filter((model) => model.provider === parsed.provider && model.id.includes(parsed.modelId))
+				: models.filter((model) => model.id.includes(parsed.modelId));
+		const partial = byProviderAndPartial
+			.filter((model) => matchesConstraints(model, constraints))
+			.sort(compareModelPriority);
+		return partial[0];
+	}
+
+	private findModelByProvider(
+		provider: string,
+		models: Model<Api>[],
+		constraints: ModelConstraints | undefined,
+	): Model<Api> | undefined {
+		const providerModels = models.filter(
+			(model) => model.provider === provider && matchesConstraints(model, constraints),
+		);
+		const sorted = providerModels.sort(compareModelPriority);
+		return sorted[0];
+	}
+}

--- a/packages/coding-agent/examples/extensions/multi-agent/src/routing/types.ts
+++ b/packages/coding-agent/examples/extensions/multi-agent/src/routing/types.ts
@@ -1,0 +1,73 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+
+export type ModelCapability = "text" | "image";
+
+export interface ModelConstraints {
+	maxInputCost?: number;
+	maxOutputCost?: number;
+	minContextWindow?: number;
+	maxContextWindow?: number;
+	requiresReasoning?: boolean;
+	requiresCapabilities?: ModelCapability[];
+}
+
+export interface ProviderKeyOverride {
+	/** Environment variable that contains the provider API key for this route. */
+	envVar?: string;
+	/** Per-provider base URL override for this route. */
+	baseUrl?: string;
+}
+
+export type ProviderKeyOverrides = Record<string, ProviderKeyOverride>;
+
+export interface AgentModelConfig {
+	/** Explicit model reference (`provider/modelId` recommended). */
+	model?: string;
+	/** Preferred provider when no explicit model is selected. */
+	provider?: string;
+	/** Ordered fallback chain of model references. */
+	modelChain?: string[];
+	/** Constraint filters applied during model selection. */
+	constraints?: ModelConstraints;
+	/** Optional category key used to merge category-level defaults. */
+	category?: string;
+	/** Agent-specific provider key/baseUrl overrides. */
+	providerKeys?: ProviderKeyOverrides;
+}
+
+export interface ModelRouterConfig {
+	agents?: Record<string, AgentModelConfig>;
+	categories?: Record<string, AgentModelConfig>;
+	providerKeys?: ProviderKeyOverrides;
+	lastResortModel?: string;
+}
+
+export interface RuntimeModelOverride {
+	model?: string;
+	provider?: string;
+}
+
+export type ModelRouteSource =
+	| "runtime-model"
+	| "runtime-provider"
+	| "agent-model"
+	| "agent-chain"
+	| "agent-provider"
+	| "category-model"
+	| "category-chain"
+	| "category-provider"
+	| "last-resort-model";
+
+export interface ResolveModelOptions {
+	category?: string;
+	runtimeOverride?: RuntimeModelOverride;
+}
+
+export interface ResolvedModelRoute {
+	agentName: string;
+	category?: string;
+	model: Model<Api>;
+	source: ModelRouteSource;
+	tried: string[];
+	providerKeyOverrides: ProviderKeyOverrides;
+}

--- a/packages/coding-agent/test/multi-agent-model-router.test.ts
+++ b/packages/coding-agent/test/multi-agent-model-router.test.ts
@@ -1,0 +1,308 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import { afterEach, describe, expect, test } from "vitest";
+import { TaskDelegator } from "../examples/extensions/multi-agent/src/orchestration/TaskDelegator.js";
+import { AgentKeyInjector } from "../examples/extensions/multi-agent/src/routing/AgentKeyInjector.js";
+import { ModelRouter } from "../examples/extensions/multi-agent/src/routing/ModelRouter.js";
+import type { ModelRouterConfig } from "../examples/extensions/multi-agent/src/routing/types.js";
+
+function createModel(params: {
+	provider: string;
+	id: string;
+	reasoning: boolean;
+	contextWindow: number;
+	input: ("text" | "image")[];
+	inputCost: number;
+	outputCost: number;
+}): Model<Api> {
+	return {
+		id: params.id,
+		name: `${params.provider}/${params.id}`,
+		api: "anthropic-messages",
+		provider: params.provider,
+		baseUrl: `https://${params.provider}.example.com`,
+		reasoning: params.reasoning,
+		input: params.input,
+		cost: {
+			input: params.inputCost,
+			output: params.outputCost,
+			cacheRead: 0,
+			cacheWrite: 0,
+		},
+		contextWindow: params.contextWindow,
+		maxTokens: 8192,
+	};
+}
+
+const models: Model<Api>[] = [
+	createModel({
+		provider: "anthropic",
+		id: "claude-sonnet-4-5",
+		reasoning: true,
+		contextWindow: 200_000,
+		input: ["text", "image"],
+		inputCost: 3,
+		outputCost: 15,
+	}),
+	createModel({
+		provider: "anthropic",
+		id: "claude-haiku-4-5",
+		reasoning: false,
+		contextWindow: 200_000,
+		input: ["text", "image"],
+		inputCost: 1,
+		outputCost: 5,
+	}),
+	createModel({
+		provider: "openai",
+		id: "gpt-4o",
+		reasoning: false,
+		contextWindow: 128_000,
+		input: ["text", "image"],
+		inputCost: 5,
+		outputCost: 15,
+	}),
+	createModel({
+		provider: "openai",
+		id: "gpt-4.1",
+		reasoning: true,
+		contextWindow: 512_000,
+		input: ["text", "image"],
+		inputCost: 10,
+		outputCost: 30,
+	}),
+	createModel({
+		provider: "openai",
+		id: "gpt-4o-mini",
+		reasoning: false,
+		contextWindow: 128_000,
+		input: ["text"],
+		inputCost: 0.3,
+		outputCost: 0.6,
+	}),
+	createModel({
+		provider: "google",
+		id: "gemini-2.5-pro",
+		reasoning: true,
+		contextWindow: 1_000_000,
+		input: ["text", "image"],
+		inputCost: 1.25,
+		outputCost: 10,
+	}),
+];
+
+function createRegistry(
+	allModels: Model<Api>[],
+	availableModels: Model<Api>[],
+): Pick<ModelRegistry, "getAll" | "getAvailable"> {
+	return {
+		getAll: () => allModels,
+		getAvailable: () => availableModels,
+	};
+}
+
+const tempPaths: string[] = [];
+
+afterEach(() => {
+	for (const tempPath of tempPaths.splice(0)) {
+		rmSync(tempPath, { recursive: true, force: true });
+	}
+});
+
+describe("ModelRouter", () => {
+	test("resolves explicit agent model reference", () => {
+		const config: ModelRouterConfig = {
+			agents: {
+				worker: { model: "openai/gpt-4o" },
+			},
+		};
+		const router = new ModelRouter(config);
+		const route = router.resolveForAgent("worker", models);
+		expect(route?.model.provider).toBe("openai");
+		expect(route?.model.id).toBe("gpt-4o");
+		expect(route?.source).toBe("agent-model");
+	});
+
+	test("applies constraints across modelChain fallback", () => {
+		const config: ModelRouterConfig = {
+			agents: {
+				planner: {
+					modelChain: ["openai/gpt-4o-mini", "anthropic/claude-sonnet-4-5"],
+					constraints: { requiresReasoning: true, requiresCapabilities: ["image"] },
+				},
+			},
+		};
+		const router = new ModelRouter(config);
+		const route = router.resolveForAgent("planner", models);
+		expect(route?.model.provider).toBe("anthropic");
+		expect(route?.model.id).toBe("claude-sonnet-4-5");
+		expect(route?.source).toBe("agent-chain");
+		expect(route?.tried).toContain("model:openai/gpt-4o-mini");
+	});
+
+	test("resolves via provider and constraints", () => {
+		const config: ModelRouterConfig = {
+			agents: {
+				architect: {
+					provider: "openai",
+					constraints: { minContextWindow: 400_000, requiresReasoning: true },
+				},
+			},
+		};
+		const router = new ModelRouter(config);
+		const route = router.resolveForAgent("architect", models);
+		expect(route?.model.provider).toBe("openai");
+		expect(route?.model.id).toBe("gpt-4.1");
+		expect(route?.source).toBe("agent-provider");
+	});
+
+	test("uses category fallback and provider key override merge", () => {
+		const config: ModelRouterConfig = {
+			providerKeys: {
+				anthropic: { envVar: "GLOBAL_ANTHROPIC_KEY" },
+			},
+			categories: {
+				planning: {
+					model: "anthropic/claude-sonnet-4-5",
+					providerKeys: {
+						anthropic: { baseUrl: "https://category.proxy" },
+					},
+				},
+			},
+			agents: {
+				worker: {
+					category: "planning",
+					providerKeys: {
+						anthropic: { envVar: "AGENT_ANTHROPIC_KEY" },
+					},
+				},
+			},
+		};
+
+		const router = new ModelRouter(config);
+		const route = router.resolveForAgent("worker", models);
+		expect(route?.source).toBe("category-model");
+		expect(route?.providerKeyOverrides.anthropic.envVar).toBe("AGENT_ANTHROPIC_KEY");
+		expect(route?.providerKeyOverrides.anthropic.baseUrl).toBe("https://category.proxy");
+	});
+
+	test("falls back to lastResortModel", () => {
+		const config: ModelRouterConfig = {
+			agents: {
+				worker: { model: "openai/does-not-exist" },
+			},
+			lastResortModel: "anthropic/claude-haiku-4-5",
+		};
+		const router = new ModelRouter(config);
+		const route = router.resolveForAgent("worker", models);
+		expect(route?.source).toBe("last-resort-model");
+		expect(route?.model.provider).toBe("anthropic");
+		expect(route?.model.id).toBe("claude-haiku-4-5");
+	});
+});
+
+describe("TaskDelegator", () => {
+	test("supports runtime set_model / set_provider / reset_model hooks", () => {
+		const registry = createRegistry(models, models);
+		const delegator = new TaskDelegator(registry, {
+			agents: {
+				worker: { provider: "anthropic" },
+			},
+		});
+
+		const initial = delegator.resolveStrategy("worker");
+		expect(initial?.source).toBe("agent-provider");
+		expect(initial?.provider).toBe("anthropic");
+		initial?.cleanup();
+
+		delegator.setModel("worker", "openai/gpt-4o");
+		const runtimeModel = delegator.resolveStrategy("worker");
+		expect(runtimeModel?.source).toBe("runtime-model");
+		expect(runtimeModel?.provider).toBe("openai");
+		expect(runtimeModel?.modelId).toBe("gpt-4o");
+		runtimeModel?.cleanup();
+
+		delegator.setProvider("worker", "openai");
+		const runtimeProvider = delegator.resolveStrategy("worker");
+		expect(runtimeProvider?.source).toBe("runtime-provider");
+		expect(runtimeProvider?.provider).toBe("openai");
+		runtimeProvider?.cleanup();
+
+		delegator.resetModel("worker");
+		const reset = delegator.resolveStrategy("worker");
+		expect(reset?.source).toBe("agent-provider");
+		expect(reset?.provider).toBe("anthropic");
+		reset?.cleanup();
+	});
+
+	test("allows unavailable model when provider key override envVar is present", () => {
+		const available = models.filter((model) => model.provider === "anthropic");
+		const registry = createRegistry(models, available);
+		const delegator = new TaskDelegator(
+			registry,
+			{
+				agents: {
+					worker: { model: "openai/gpt-4o" },
+				},
+				providerKeys: {
+					openai: { envVar: "TEAM_OPENAI_KEY" },
+				},
+			},
+			{
+				...process.env,
+				TEAM_OPENAI_KEY: "secret-openai-key",
+			},
+		);
+
+		const strategy = delegator.resolveStrategy("worker");
+		expect(strategy?.provider).toBe("openai");
+		expect(strategy?.modelId).toBe("gpt-4o");
+		expect(strategy?.env.OPENAI_API_KEY).toBe("secret-openai-key");
+		strategy?.cleanup();
+	});
+});
+
+describe("AgentKeyInjector", () => {
+	test("creates temporary agent dir for baseUrl overrides and copies auth.json", () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "pi-router-agent-"));
+		tempPaths.push(agentDir);
+
+		writeFileSync(join(agentDir, "auth.json"), JSON.stringify({ providers: { anthropic: { type: "apiKey" } } }));
+		writeFileSync(
+			join(agentDir, "models.json"),
+			JSON.stringify({
+				providers: {
+					openai: {
+						baseUrl: "https://api.openai.com",
+					},
+				},
+			}),
+		);
+
+		const injector = new AgentKeyInjector({ agentDir, baseEnv: process.env });
+		const injected = injector.inject({
+			anthropic: {
+				baseUrl: "https://proxy.anthropic.internal",
+			},
+		});
+
+		const tempAgentDir = injected.env.PI_CODING_AGENT_DIR;
+		expect(typeof tempAgentDir).toBe("string");
+		expect(tempAgentDir).not.toBe(agentDir);
+		expect(tempAgentDir).toBeTruthy();
+
+		const tempModelsPath = join(tempAgentDir as string, "models.json");
+		const parsed = JSON.parse(readFileSync(tempModelsPath, "utf-8")) as {
+			providers: Record<string, { baseUrl?: string }>;
+		};
+		expect(parsed.providers.anthropic.baseUrl).toBe("https://proxy.anthropic.internal");
+		expect(parsed.providers.openai.baseUrl).toBe("https://api.openai.com");
+		expect(existsSync(join(tempAgentDir as string, "auth.json"))).toBe(true);
+
+		injected.cleanup();
+		expect(existsSync(tempAgentDir as string)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- add a new multi-agent extension scaffold with typed ModelRouter, TaskDelegator, and AgentKeyInjector layers
- implement agent/category/runtime model resolution with model/provider/modelChain precedence, constraint filtering, category fallback, and last-resort fallback handling
- add runtime command hooks: agent.list_models, agent.get_model, agent.set_model, agent.set_provider, agent.reset_model, and agent.list_available_models
- add tests for routing, constraints, fallback behavior, runtime overrides, and provider key/baseUrl injection

## Validation
- npx tsx ../../node_modules/vitest/dist/cli.js --run test/multi-agent-model-router.test.ts (from packages/coding-agent)
- npm run check

Closes #1
