### PR TITLE
feat: support ChatGPT Plan OAuth model access

### DIFF
--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -51,7 +51,7 @@ function hasVertexAdcCredentials(): boolean {
 /**
  * Get API key for provider from known environment variables, e.g. OPENAI_API_KEY.
  *
- * Will not return API keys for providers that require OAuth tokens.
+ * OAuth-first providers may optionally define API-key fallbacks (for example openai-codex -> OPENAI_API_KEY).
  */
 export function getEnvApiKey(provider: KnownProvider): string | undefined;
 export function getEnvApiKey(provider: string): string | undefined;
@@ -100,6 +100,8 @@ export function getEnvApiKey(provider: any): string | undefined {
 
 	const envMap: Record<string, string> = {
 		openai: "OPENAI_API_KEY",
+		// Fallback for OpenAI Codex provider when using OpenAI API keys instead of ChatGPT OAuth tokens.
+		"openai-codex": "OPENAI_API_KEY",
 		"azure-openai-responses": "AZURE_OPENAI_API_KEY",
 		google: "GEMINI_API_KEY",
 		groq: "GROQ_API_KEY",

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -27,6 +27,7 @@ import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 // ============================================================================
 
 const DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
+const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth" as const;
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
@@ -67,8 +68,20 @@ interface RequestBody {
 	text?: { verbosity?: string };
 	include?: string[];
 	prompt_cache_key?: string;
+	prompt_cache_retention?: "in-memory";
 	[key: string]: unknown;
 }
+
+type CodexAuthMode = "chatgpt-plan-oauth" | "openai-api-key";
+
+type ResolvedCodexAuth =
+	| {
+			mode: "chatgpt-plan-oauth";
+			accountId: string;
+	  }
+	| {
+			mode: "openai-api-key";
+	  };
 
 // ============================================================================
 // Retry Helpers
@@ -131,18 +144,27 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 				throw new Error(`No API key for provider: ${model.provider}`);
 			}
 
-			const accountId = extractAccountId(apiKey);
+			const auth = resolveCodexAuth(apiKey);
 			const body = buildRequestBody(model, context, options);
 			options?.onPayload?.(body);
-			const headers = buildHeaders(model.headers, options?.headers, accountId, apiKey, options?.sessionId);
+			const headers = buildHeaders(model.headers, options?.headers, auth, apiKey, options?.sessionId);
 			const bodyJson = JSON.stringify(body);
-			const transport = options?.transport || "sse";
+			const requestUrl = resolveCodexUrl(model.baseUrl, auth.mode);
+			const requestedTransport = options?.transport || "sse";
+
+			if (auth.mode === "openai-api-key" && requestedTransport === "websocket") {
+				throw new Error(
+					"WebSocket transport requires ChatGPT Plan OAuth. Use /login openai-codex or use transport=sse/auto.",
+				);
+			}
+
+			const transport = auth.mode === "chatgpt-plan-oauth" ? requestedTransport : "sse";
 
 			if (transport !== "sse") {
 				let websocketStarted = false;
 				try {
 					await processWebSocketStream(
-						resolveCodexWebSocketUrl(model.baseUrl),
+						resolveCodexWebSocketUrl(model.baseUrl, auth.mode),
 						body,
 						headers,
 						output,
@@ -181,7 +203,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 				}
 
 				try {
-					response = await fetch(resolveCodexUrl(model.baseUrl), {
+					response = await fetch(requestUrl, {
 						method: "POST",
 						headers,
 						body: bodyJson,
@@ -204,7 +226,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 						status: response.status,
 						statusText: response.statusText,
 					});
-					const info = await parseErrorResponse(fakeResponse);
+					const info = await parseErrorResponse(fakeResponse, auth.mode);
 					throw new Error(info.friendlyMessage || info.message);
 				} catch (error) {
 					if (error instanceof Error) {
@@ -292,6 +314,7 @@ function buildRequestBody(
 		text: { verbosity: options?.textVerbosity || "medium" },
 		include: ["reasoning.encrypted_content"],
 		prompt_cache_key: options?.sessionId,
+		prompt_cache_retention: options?.sessionId ? "in-memory" : undefined,
 		tool_choice: "auto",
 		parallel_tool_calls: true,
 	};
@@ -322,7 +345,13 @@ function clampReasoningEffort(modelId: string, effort: string): string {
 	return effort;
 }
 
-function resolveCodexUrl(baseUrl?: string): string {
+function resolveCodexUrl(baseUrl: string | undefined, mode: CodexAuthMode): string {
+	if (mode === "openai-api-key") {
+		const normalized = DEFAULT_OPENAI_BASE_URL.replace(/\/+$/, "");
+		if (normalized.endsWith("/responses")) return normalized;
+		return `${normalized}/responses`;
+	}
+
 	const raw = baseUrl && baseUrl.trim().length > 0 ? baseUrl : DEFAULT_CODEX_BASE_URL;
 	const normalized = raw.replace(/\/+$/, "");
 	if (normalized.endsWith("/codex/responses")) return normalized;
@@ -330,8 +359,12 @@ function resolveCodexUrl(baseUrl?: string): string {
 	return `${normalized}/codex/responses`;
 }
 
-function resolveCodexWebSocketUrl(baseUrl?: string): string {
-	const url = new URL(resolveCodexUrl(baseUrl));
+function resolveCodexWebSocketUrl(baseUrl: string | undefined, mode: CodexAuthMode): string {
+	if (mode !== "chatgpt-plan-oauth") {
+		throw new Error("WebSocket transport is only available with ChatGPT Plan OAuth authentication.");
+	}
+
+	const url = new URL(resolveCodexUrl(baseUrl, mode));
 	if (url.protocol === "https:") url.protocol = "wss:";
 	if (url.protocol === "http:") url.protocol = "ws:";
 	return url.toString();
@@ -791,7 +824,10 @@ async function processWebSocketStream(
 // Error Handling
 // ============================================================================
 
-async function parseErrorResponse(response: Response): Promise<{ message: string; friendlyMessage?: string }> {
+async function parseErrorResponse(
+	response: Response,
+	mode: CodexAuthMode,
+): Promise<{ message: string; friendlyMessage?: string }> {
 	const raw = await response.text();
 	let message = raw || response.statusText || "Request failed";
 	let friendlyMessage: string | undefined;
@@ -809,7 +845,8 @@ async function parseErrorResponse(response: Response): Promise<{ message: string
 					? Math.max(0, Math.round((err.resets_at * 1000 - Date.now()) / 60000))
 					: undefined;
 				const when = mins !== undefined ? ` Try again in ~${mins} min.` : "";
-				friendlyMessage = `You have hit your ChatGPT usage limit${plan}.${when}`.trim();
+				const providerLabel = mode === "chatgpt-plan-oauth" ? "ChatGPT" : "OpenAI API";
+				friendlyMessage = `You have hit your ${providerLabel} usage limit${plan}.${when}`.trim();
 			}
 			message = err.message || friendlyMessage || message;
 		}
@@ -822,31 +859,42 @@ async function parseErrorResponse(response: Response): Promise<{ message: string
 // Auth & Headers
 // ============================================================================
 
-function extractAccountId(token: string): string {
+function tryExtractAccountId(token: string): string | undefined {
 	try {
 		const parts = token.split(".");
-		if (parts.length !== 3) throw new Error("Invalid token");
+		if (parts.length !== 3) return undefined;
 		const payload = JSON.parse(atob(parts[1]));
 		const accountId = payload?.[JWT_CLAIM_PATH]?.chatgpt_account_id;
-		if (!accountId) throw new Error("No account ID in token");
-		return accountId;
+		return typeof accountId === "string" && accountId.length > 0 ? accountId : undefined;
 	} catch {
-		throw new Error("Failed to extract accountId from token");
+		return undefined;
 	}
+}
+
+function resolveCodexAuth(token: string): ResolvedCodexAuth {
+	const accountId = tryExtractAccountId(token);
+	if (accountId) {
+		return { mode: "chatgpt-plan-oauth", accountId };
+	}
+	return { mode: "openai-api-key" };
 }
 
 function buildHeaders(
 	initHeaders: Record<string, string> | undefined,
 	additionalHeaders: Record<string, string> | undefined,
-	accountId: string,
+	auth: ResolvedCodexAuth,
 	token: string,
 	sessionId?: string,
 ): Headers {
 	const headers = new Headers(initHeaders);
 	headers.set("Authorization", `Bearer ${token}`);
-	headers.set("chatgpt-account-id", accountId);
-	headers.set("OpenAI-Beta", "responses=experimental");
-	headers.set("originator", "pi");
+
+	if (auth.mode === "chatgpt-plan-oauth") {
+		headers.set("chatgpt-account-id", auth.accountId);
+		headers.set("OpenAI-Beta", "responses=experimental");
+		headers.set("originator", "pi");
+	}
+
 	const userAgent = _os ? `pi (${_os.platform()} ${_os.release()}; ${_os.arch()})` : "pi (browser)";
 	headers.set("User-Agent", userAgent);
 	headers.set("accept", "text/event-stream");
@@ -855,7 +903,8 @@ function buildHeaders(
 		headers.set(key, value);
 	}
 
-	if (sessionId) {
+	if (sessionId && auth.mode === "chatgpt-plan-oauth") {
+		headers.set("conversation_id", sessionId);
 		headers.set("session_id", sessionId);
 	}
 

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -433,7 +433,7 @@ export async function refreshOpenAICodexToken(refreshToken: string): Promise<OAu
 
 export const openaiCodexOAuthProvider: OAuthProviderInterface = {
 	id: "openai-codex",
-	name: "ChatGPT Plus/Pro (Codex Subscription)",
+	name: "ChatGPT Plan (Codex)",
 	usesCallbackServer: true,
 
 	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -7,6 +7,7 @@ import type { Context, Model } from "../src/types.js";
 
 const originalFetch = global.fetch;
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
 
 afterEach(() => {
 	global.fetch = originalFetch;
@@ -14,6 +15,11 @@ afterEach(() => {
 		delete process.env.PI_CODING_AGENT_DIR;
 	} else {
 		process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+	}
+	if (originalOpenAiApiKey === undefined) {
+		delete process.env.OPENAI_API_KEY;
+	} else {
+		process.env.OPENAI_API_KEY = originalOpenAiApiKey;
 	}
 	vi.restoreAllMocks();
 });
@@ -127,6 +133,94 @@ describe("openai-codex streaming", () => {
 		}
 
 		expect(sawTextDelta).toBe(true);
+		expect(sawDone).toBe(true);
+	});
+
+	it("falls back to OpenAI API endpoint when using OPENAI_API_KEY", async () => {
+		process.env.OPENAI_API_KEY = "sk-openai-test";
+
+		const sse = `${[
+			`data: ${JSON.stringify({
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+			})}`,
+			`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+			`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
+			`data: ${JSON.stringify({
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_1",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hello" }],
+				},
+			})}`,
+			`data: ${JSON.stringify({
+				type: "response.completed",
+				response: {
+					status: "completed",
+					usage: {
+						input_tokens: 5,
+						output_tokens: 3,
+						total_tokens: 8,
+						input_tokens_details: { cached_tokens: 0 },
+					},
+				},
+			})}`,
+		].join("\n\n")}\n\n`;
+
+		const encoder = new TextEncoder();
+		const responseStream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.openai.com/v1/responses") {
+				const headers = init?.headers instanceof Headers ? init.headers : undefined;
+				expect(headers?.get("Authorization")).toBe("Bearer sk-openai-test");
+				expect(headers?.has("chatgpt-account-id")).toBe(false);
+				expect(headers?.has("originator")).toBe(false);
+				return new Response(responseStream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		});
+
+		global.fetch = fetchMock as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.2-codex",
+			name: "GPT-5.2 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const streamResult = streamOpenAICodexResponses(model, context, { transport: "auto" });
+		let sawDone = false;
+		for await (const event of streamResult) {
+			if (event.type === "done") {
+				sawDone = true;
+				expect(event.message.content.find((c) => c.type === "text")?.text).toBe("Hello");
+			}
+		}
 		expect(sawDone).toBe(true);
 	});
 

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -16,7 +16,7 @@ Pi supports subscription-based providers via OAuth and API key providers via env
 Use `/login` in interactive mode, then select a provider:
 
 - Claude Pro/Max
-- ChatGPT Plus/Pro (Codex)
+- ChatGPT Plan (Codex)
 - GitHub Copilot
 - Google Gemini CLI
 - Google Antigravity
@@ -37,8 +37,9 @@ Use `/logout` to clear credentials. Tokens are stored in `~/.pi/agent/auth.json`
 
 ### OpenAI Codex
 
-- Requires ChatGPT Plus or Pro subscription
+- Requires a ChatGPT plan with Codex access
 - Personal use only; for production, use the OpenAI Platform API
+- If both are configured, pi prefers ChatGPT OAuth for `openai-codex` and falls back to OpenAI API credentials when OAuth is unavailable.
 
 ## API Keys
 
@@ -184,3 +185,5 @@ When resolving credentials for a provider:
 2. `auth.json` entry (API key or OAuth token)
 3. Environment variable
 4. Custom provider keys from `models.json`
+
+`openai-codex` uses the same order, then falls back to `openai` credentials (for example `OPENAI_API_KEY`).

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -276,7 +276,7 @@ ${chalk.bold("Examples:")}
 ${chalk.bold("Environment Variables:")}
   ANTHROPIC_API_KEY                - Anthropic Claude API key
   ANTHROPIC_OAUTH_TOKEN            - Anthropic OAuth token (alternative to API key)
-  OPENAI_API_KEY                   - OpenAI GPT API key
+  OPENAI_API_KEY                   - OpenAI GPT API key (also fallback for openai-codex)
   AZURE_OPENAI_API_KEY             - Azure OpenAI API key
   AZURE_OPENAI_BASE_URL            - Azure OpenAI base URL (https://{resource}.openai.azure.com/openai/v1)
   AZURE_OPENAI_RESOURCE_NAME       - Azure OpenAI resource name (alternative to base URL)

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -21,6 +21,11 @@ import lockfile from "proper-lockfile";
 import { getAgentDir } from "../config.js";
 import { resolveConfigValue } from "./resolve-config-value.js";
 
+const AUTH_PROVIDER_FALLBACKS: Record<string, string[]> = {
+	// ChatGPT Plan (openai-codex) can use OpenAI API keys as a fallback.
+	"openai-codex": ["openai"],
+};
+
 export type ApiKeyCredential = {
 	type: "api_key";
 	key: string;
@@ -297,10 +302,12 @@ export class AuthStorage {
 	 * Unlike getApiKey(), this doesn't refresh OAuth tokens.
 	 */
 	hasAuth(provider: string): boolean {
-		if (this.runtimeOverrides.has(provider)) return true;
-		if (this.data[provider]) return true;
-		if (getEnvApiKey(provider)) return true;
-		if (this.fallbackResolver?.(provider)) return true;
+		for (const candidate of this.getProviderCandidates(provider)) {
+			if (this.runtimeOverrides.has(candidate)) return true;
+			if (this.data[candidate]) return true;
+			if (getEnvApiKey(candidate)) return true;
+			if (this.fallbackResolver?.(candidate)) return true;
+		}
 		return false;
 	}
 
@@ -395,8 +402,24 @@ export class AuthStorage {
 	 * 3. OAuth token from auth.json (auto-refreshed with locking)
 	 * 4. Environment variable
 	 * 5. Fallback resolver (models.json custom providers)
+	 *
+	 * For providers with configured fallbacks (for example `openai-codex`),
+	 * this order is applied to the provider first, then each fallback provider.
 	 */
 	async getApiKey(providerId: string): Promise<string | undefined> {
+		for (const candidate of this.getProviderCandidates(providerId)) {
+			const apiKey = await this.getApiKeyForProvider(candidate);
+			if (apiKey) return apiKey;
+		}
+		return undefined;
+	}
+
+	private getProviderCandidates(providerId: string): string[] {
+		const fallbacks = AUTH_PROVIDER_FALLBACKS[providerId] ?? [];
+		return [providerId, ...fallbacks.filter((candidate) => candidate !== providerId)];
+	}
+
+	private async getApiKeyForProvider(providerId: string): Promise<string | undefined> {
 		// Runtime override takes highest priority
 		const runtimeKey = this.runtimeOverrides.get(providerId);
 		if (runtimeKey) {

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -14,9 +14,9 @@ import type { ModelRegistry } from "./model-registry.js";
 export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	"amazon-bedrock": "us.anthropic.claude-opus-4-6-v1",
 	anthropic: "claude-opus-4-6",
+	"openai-codex": "gpt-5.3-codex",
 	openai: "gpt-5.1-codex",
 	"azure-openai-responses": "gpt-5.2",
-	"openai-codex": "gpt-5.3-codex",
 	google: "gemini-2.5-pro",
 	"google-gemini-cli": "gemini-2.5-pro",
 	"google-antigravity": "gemini-3-pro-high",

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -7,6 +7,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { clearConfigValueCache } from "../src/core/resolve-config-value.js";
 
+const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
+
 describe("AuthStorage", () => {
 	let tempDir: string;
 	let authJsonPath: string;
@@ -21,6 +23,11 @@ describe("AuthStorage", () => {
 	afterEach(() => {
 		if (tempDir && existsSync(tempDir)) {
 			rmSync(tempDir, { recursive: true });
+		}
+		if (originalOpenAiApiKey === undefined) {
+			delete process.env.OPENAI_API_KEY;
+		} else {
+			process.env.OPENAI_API_KEY = originalOpenAiApiKey;
 		}
 		clearConfigValueCache();
 		vi.restoreAllMocks();
@@ -449,6 +456,38 @@ describe("AuthStorage", () => {
 			const apiKey = await authStorage.getApiKey("anthropic");
 
 			expect(apiKey).toBe("stored-key");
+		});
+	});
+
+	describe("provider fallbacks", () => {
+		test("openai-codex falls back to openai API key when codex credentials are missing", async () => {
+			writeAuthJson({
+				openai: { type: "api_key", key: "sk-openai-fallback" },
+			});
+
+			authStorage = AuthStorage.create(authJsonPath);
+			const apiKey = await authStorage.getApiKey("openai-codex");
+
+			expect(apiKey).toBe("sk-openai-fallback");
+		});
+
+		test("openai-codex prefers its own OAuth token over openai fallback key", async () => {
+			process.env.OPENAI_API_KEY = "sk-openai-env";
+
+			writeAuthJson({
+				"openai-codex": {
+					type: "oauth",
+					access: "chatgpt-oauth-token",
+					refresh: "refresh-token",
+					expires: Date.now() + 60_000,
+				},
+				openai: { type: "api_key", key: "sk-openai-fallback" },
+			});
+
+			authStorage = AuthStorage.create(authJsonPath);
+			const apiKey = await authStorage.getApiKey("openai-codex");
+
+			expect(apiKey).toBe("chatgpt-oauth-token");
 		});
 	});
 });

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -360,6 +360,46 @@ describe("default model selection", () => {
 		expect(defaultModelPerProvider["vercel-ai-gateway"]).toBe("anthropic/claude-opus-4-6");
 	});
 
+	test("openai-codex default is preferred over openai when both are available", async () => {
+		const openaiCodexModel: Model<"openai-responses"> = {
+			id: "gpt-5.3-codex",
+			name: "GPT-5.3 Codex",
+			api: "openai-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 272000,
+			maxTokens: 128000,
+		};
+		const openaiModel: Model<"openai-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 272000,
+			maxTokens: 128000,
+		};
+
+		const registry = {
+			getAvailable: async () => [openaiModel, openaiCodexModel],
+		} as unknown as Parameters<typeof findInitialModel>[0]["modelRegistry"];
+
+		const result = await findInitialModel({
+			scopedModels: [],
+			isContinuing: false,
+			modelRegistry: registry,
+		});
+
+		expect(result.model?.provider).toBe("openai-codex");
+		expect(result.model?.id).toBe("gpt-5.3-codex");
+	});
+
 	test("findInitialModel selects ai-gateway default when available", async () => {
 		const aiGatewayModel: Model<"anthropic-messages"> = {
 			id: "anthropic/claude-opus-4-6",


### PR DESCRIPTION
## Summary\n- add ChatGPT Plan/OpenAI API fallback handling for `openai-codex` credentials and routing\n- prefer ChatGPT Plan defaults in model resolver and auth fallback resolution\n- update provider/docs/help text and add regression tests for auth priority + fallback behavior\n\n## Validation\n- npm run check\n- npx tsx ../../node_modules/vitest/dist/cli.js --run test/openai-codex-stream.test.ts\n- npx tsx ../../node_modules/vitest/dist/cli.js --run test/auth-storage.test.ts test/model-resolver.test.ts\n\nCloses #3