### PR TITLE
fix(ai): harden prompt_cache_retention compatibility for codex/oauth

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -29,6 +29,7 @@ import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 const DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth" as const;
+const OPENAI_API_HOST = "api.openai.com";
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
 const CODEX_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
@@ -53,6 +54,9 @@ export interface OpenAICodexResponsesOptions extends StreamOptions {
 }
 
 type CodexResponseStatus = "completed" | "incomplete" | "failed" | "cancelled" | "queued" | "in_progress";
+type PromptCacheRetentionWarningReason =
+	| "unsupported_endpoint_capability_unknown"
+	| "unsupported_parameter_retry_without_prompt_cache_retention";
 
 interface RequestBody {
 	model: string;
@@ -72,6 +76,10 @@ interface RequestBody {
 	[key: string]: unknown;
 }
 
+interface BuildRequestBodyOptions {
+	includePromptCacheRetention: boolean;
+}
+
 type CodexAuthMode = "chatgpt-plan-oauth" | "openai-api-key";
 
 type ResolvedCodexAuth =
@@ -82,6 +90,8 @@ type ResolvedCodexAuth =
 	| {
 			mode: "openai-api-key";
 	  };
+
+class NonRetryableRequestError extends Error {}
 
 // ============================================================================
 // Retry Helpers
@@ -105,6 +115,71 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 			clearTimeout(timeout);
 			reject(new Error("Request was aborted"));
 		});
+	});
+}
+
+function getEndpointHost(url: string): string | undefined {
+	try {
+		return new URL(url).host;
+	} catch {
+		return undefined;
+	}
+}
+
+function supportsPromptCacheRetention(mode: CodexAuthMode, requestUrl: string): boolean {
+	if (mode !== "openai-api-key") return false;
+	try {
+		return new URL(requestUrl).hostname === OPENAI_API_HOST;
+	} catch {
+		return false;
+	}
+}
+
+function isUnsupportedPromptCacheRetentionError(status: number, errorText: string): boolean {
+	if (status !== 400 && status !== 422) return false;
+
+	let parsed: Record<string, unknown> | undefined;
+	try {
+		parsed = JSON.parse(errorText) as Record<string, unknown>;
+	} catch {
+		// ignore parse failures
+	}
+
+	const rootParam = parsed?.param;
+	const rootMessage = parsed?.message;
+	const errorObject =
+		parsed?.error && typeof parsed.error === "object" && parsed.error !== null
+			? (parsed.error as Record<string, unknown>)
+			: undefined;
+	const errorParam = errorObject?.param;
+	const errorMessage = errorObject?.message;
+	const hasPromptCacheParam =
+		rootParam === "prompt_cache_retention" ||
+		errorParam === "prompt_cache_retention" ||
+		/prompt_cache_retention/i.test(errorText);
+
+	if (!hasPromptCacheParam) return false;
+
+	const messages = [errorText, rootMessage, errorMessage]
+		.filter((value): value is string => typeof value === "string")
+		.map((value) => value.toLowerCase());
+
+	return messages.some((message) =>
+		/(unsupported parameter|unknown parameter|unexpected parameter|not (supported|allowed|permitted))/i.test(message),
+	);
+}
+
+function logPromptCacheRetentionWarning(
+	requestUrl: string,
+	authMode: CodexAuthMode,
+	reason: PromptCacheRetentionWarningReason,
+	status?: number,
+): void {
+	console.warn("[openai-codex-responses] prompt_cache_retention compatibility", {
+		reason,
+		authMode,
+		endpointHost: getEndpointHost(requestUrl),
+		...(status !== undefined ? { status } : {}),
 	});
 }
 
@@ -145,11 +220,15 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 			}
 
 			const auth = resolveCodexAuth(apiKey);
-			const body = buildRequestBody(model, context, options);
+			const requestUrl = resolveCodexUrl(model.baseUrl, auth.mode);
+			const includePromptCacheRetention = supportsPromptCacheRetention(auth.mode, requestUrl);
+			const body = buildRequestBody(model, context, options, { includePromptCacheRetention });
+			if (options?.sessionId && !includePromptCacheRetention) {
+				logPromptCacheRetentionWarning(requestUrl, auth.mode, "unsupported_endpoint_capability_unknown");
+			}
 			options?.onPayload?.(body);
 			const headers = buildHeaders(model.headers, options?.headers, auth, apiKey, options?.sessionId);
-			const bodyJson = JSON.stringify(body);
-			const requestUrl = resolveCodexUrl(model.baseUrl, auth.mode);
+			let bodyJson = JSON.stringify(body);
 			const requestedTransport = options?.transport || "sse";
 
 			if (auth.mode === "openai-api-key" && requestedTransport === "websocket") {
@@ -196,6 +275,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 			// Fetch with retry logic for rate limits and transient errors
 			let response: Response | undefined;
 			let lastError: Error | undefined;
+			let didRetryWithoutPromptCacheRetention = false;
 
 			for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
 				if (options?.signal?.aborted) {
@@ -215,6 +295,22 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 					}
 
 					const errorText = await response.text();
+					if (
+						!didRetryWithoutPromptCacheRetention &&
+						body.prompt_cache_retention &&
+						isUnsupportedPromptCacheRetentionError(response.status, errorText)
+					) {
+						didRetryWithoutPromptCacheRetention = true;
+						delete body.prompt_cache_retention;
+						bodyJson = JSON.stringify(body);
+						logPromptCacheRetentionWarning(
+							requestUrl,
+							auth.mode,
+							"unsupported_parameter_retry_without_prompt_cache_retention",
+							response.status,
+						);
+						continue;
+					}
 					if (attempt < MAX_RETRIES && isRetryableError(response.status, errorText)) {
 						const delayMs = BASE_DELAY_MS * 2 ** attempt;
 						await sleep(delayMs, options?.signal);
@@ -227,7 +323,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 						statusText: response.statusText,
 					});
 					const info = await parseErrorResponse(fakeResponse, auth.mode);
-					throw new Error(info.friendlyMessage || info.message);
+					throw new NonRetryableRequestError(info.friendlyMessage || info.message);
 				} catch (error) {
 					if (error instanceof Error) {
 						if (error.name === "AbortError" || error.message === "Request was aborted") {
@@ -235,6 +331,9 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 						}
 					}
 					lastError = error instanceof Error ? error : new Error(String(error));
+					if (lastError instanceof NonRetryableRequestError) {
+						throw lastError;
+					}
 					// Network errors are retryable
 					if (attempt < MAX_RETRIES && !lastError.message.includes("usage limit")) {
 						const delayMs = BASE_DELAY_MS * 2 ** attempt;
@@ -300,6 +399,7 @@ function buildRequestBody(
 	model: Model<"openai-codex-responses">,
 	context: Context,
 	options?: OpenAICodexResponsesOptions,
+	buildOptions?: BuildRequestBodyOptions,
 ): RequestBody {
 	const messages = convertResponsesMessages(model, context, CODEX_TOOL_CALL_PROVIDERS, {
 		includeSystemPrompt: false,
@@ -314,7 +414,7 @@ function buildRequestBody(
 		text: { verbosity: options?.textVerbosity || "medium" },
 		include: ["reasoning.encrypted_content"],
 		prompt_cache_key: options?.sessionId,
-		prompt_cache_retention: options?.sessionId ? "in-memory" : undefined,
+		prompt_cache_retention: buildOptions?.includePromptCacheRetention && options?.sessionId ? "in-memory" : undefined,
 		tool_choice: "auto",
 		parallel_tool_calls: true,
 	};

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -24,6 +24,68 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
+function createHelloSseStream(text = "Hello"): ReadableStream<Uint8Array> {
+	const sse = `${[
+		`data: ${JSON.stringify({
+			type: "response.output_item.added",
+			item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+		})}`,
+		`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
+		`data: ${JSON.stringify({ type: "response.output_text.delta", delta: text })}`,
+		`data: ${JSON.stringify({
+			type: "response.output_item.done",
+			item: {
+				type: "message",
+				id: "msg_1",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text }],
+			},
+		})}`,
+		`data: ${JSON.stringify({
+			type: "response.completed",
+			response: {
+				status: "completed",
+				usage: {
+					input_tokens: 5,
+					output_tokens: 3,
+					total_tokens: 8,
+					input_tokens_details: { cached_tokens: 0 },
+				},
+			},
+		})}`,
+	].join("\n\n")}\n\n`;
+
+	const encoder = new TextEncoder();
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(encoder.encode(sse));
+			controller.close();
+		},
+	});
+}
+
+function parseRequestBody(init?: RequestInit): Record<string, unknown> | null {
+	if (typeof init?.body !== "string") return null;
+	return JSON.parse(init.body) as Record<string, unknown>;
+}
+
+function buildUnsupportedPromptCacheRetentionResponse(): Response {
+	return new Response(
+		JSON.stringify({
+			error: {
+				type: "invalid_request_error",
+				param: "prompt_cache_retention",
+				message: "Unsupported parameter: prompt_cache_retention",
+			},
+		}),
+		{
+			status: 400,
+			headers: { "content-type": "application/json" },
+		},
+	);
+}
+
 describe("openai-codex streaming", () => {
 	it("streams SSE responses into AssistantMessageEventStream", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
@@ -224,9 +286,53 @@ describe("openai-codex streaming", () => {
 		expect(sawDone).toBe(true);
 	});
 
-	it("sets conversation_id/session_id headers and prompt_cache_key when sessionId is provided", async () => {
+	it("sends prompt_cache_retention on supported OpenAI API endpoint when sessionId is provided", async () => {
+		process.env.OPENAI_API_KEY = "sk-openai-test";
+
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.openai.com/v1/responses") {
+				const body = parseRequestBody(init);
+				expect(body?.prompt_cache_key).toBe("session-supported-endpoint");
+				expect(body?.prompt_cache_retention).toBe("in-memory");
+				return new Response(createHelloSseStream(), {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		});
+
+		global.fetch = fetchMock as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		await streamOpenAICodexResponses(model, context, {
+			sessionId: "session-supported-endpoint",
+			transport: "auto",
+		}).result();
+	});
+
+	it("sets conversation_id/session_id headers and prompt_cache_key but omits prompt_cache_retention for oauth mode", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
 		process.env.PI_CODING_AGENT_DIR = tempDir;
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
 		const payload = Buffer.from(
 			JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acc_test" } }),
@@ -289,9 +395,9 @@ describe("openai-codex streaming", () => {
 				expect(headers?.get("session_id")).toBe(sessionId);
 
 				// Verify sessionId is set in request body as prompt_cache_key
-				const body = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : null;
+				const body = parseRequestBody(init);
 				expect(body?.prompt_cache_key).toBe(sessionId);
-				expect(body?.prompt_cache_retention).toBe("in-memory");
+				expect(body?.prompt_cache_retention).toBeUndefined();
 
 				return new Response(stream, {
 					status: 200,
@@ -323,6 +429,130 @@ describe("openai-codex streaming", () => {
 
 		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token, sessionId });
 		await streamResult.result();
+		expect(warnSpy).toHaveBeenCalledWith(
+			"[openai-codex-responses] prompt_cache_retention compatibility",
+			expect.objectContaining({
+				reason: "unsupported_endpoint_capability_unknown",
+				authMode: "chatgpt-plan-oauth",
+				endpointHost: "chatgpt.com",
+			}),
+		);
+	});
+
+	it("retries once without prompt_cache_retention on explicit unsupported-parameter errors", async () => {
+		process.env.OPENAI_API_KEY = "sk-openai-test";
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		let attempts = 0;
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url !== "https://api.openai.com/v1/responses") {
+				return new Response("not found", { status: 404 });
+			}
+
+			attempts += 1;
+			const body = parseRequestBody(init);
+			if (attempts === 1) {
+				expect(body?.prompt_cache_retention).toBe("in-memory");
+				return buildUnsupportedPromptCacheRetentionResponse();
+			}
+
+			expect(body?.prompt_cache_retention).toBeUndefined();
+			expect(body?.prompt_cache_key).toBe("session-retry-once");
+			return new Response(createHelloSseStream(), {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			});
+		});
+
+		global.fetch = fetchMock as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const message = await streamOpenAICodexResponses(model, context, {
+			sessionId: "session-retry-once",
+			transport: "auto",
+		}).result();
+
+		expect(message.stopReason).toBe("stop");
+		expect(attempts).toBe(2);
+		expect(warnSpy).toHaveBeenCalledWith(
+			"[openai-codex-responses] prompt_cache_retention compatibility",
+			expect.objectContaining({
+				reason: "unsupported_parameter_retry_without_prompt_cache_retention",
+				authMode: "openai-api-key",
+				status: 400,
+				endpointHost: "api.openai.com",
+			}),
+		);
+	});
+
+	it("does not retry in a loop when unsupported-parameter errors repeat", async () => {
+		process.env.OPENAI_API_KEY = "sk-openai-test";
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		let attempts = 0;
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url !== "https://api.openai.com/v1/responses") {
+				return new Response("not found", { status: 404 });
+			}
+
+			attempts += 1;
+			const body = parseRequestBody(init);
+			if (attempts === 1) {
+				expect(body?.prompt_cache_retention).toBe("in-memory");
+			} else {
+				expect(body?.prompt_cache_retention).toBeUndefined();
+			}
+			return buildUnsupportedPromptCacheRetentionResponse();
+		});
+
+		global.fetch = fetchMock as typeof fetch;
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const message = await streamOpenAICodexResponses(model, context, {
+			sessionId: "session-no-loop",
+			transport: "auto",
+		}).result();
+
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("Unsupported parameter: prompt_cache_retention");
+		expect(attempts).toBe(2);
+		expect(warnSpy).toHaveBeenCalledTimes(1);
 	});
 
 	it("clamps gpt-5.3-codex minimal reasoning effort to low", async () => {


### PR DESCRIPTION
## Summary
- make prompt_cache_retention capability-aware in openai-codex-responses
- default ChatGPT OAuth requests to omit prompt_cache_retention while keeping prompt_cache_key
- add one-time retry without prompt_cache_retention on explicit unsupported-parameter errors
- add structured diagnostics for suppression/retry without leaking secrets
- stop retry loops for non-retryable server errors

## Tests
- npm run check
- cd packages/ai && npx tsx ../../node_modules/vitest/dist/cli.js --run test/openai-codex-stream.test.ts
- cd packages/ai && npx tsx ../../node_modules/vitest/dist/cli.js --run test/cache-retention.test.ts

Closes #5