### PR TITLE
fix: harden TUI render path for Apple Terminal IME crash

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -107,6 +107,17 @@ function parseSizeValue(value: SizeValue | undefined, referenceSize: number): nu
 	return undefined;
 }
 
+function detectSafeRenderMode(): boolean {
+	const override = process.env.PI_TUI_SAFE_MODE;
+	if (override === "1") {
+		return true;
+	}
+	if (override === "0") {
+		return false;
+	}
+	return process.env.TERM_PROGRAM === "Apple_Terminal";
+}
+
 /**
  * Options for overlay positioning and sizing.
  * Values can be absolute numbers or percentage strings (e.g., "50%").
@@ -214,6 +225,8 @@ export class TUI extends Container {
 	private cellSizeQueryPending = false;
 	private showHardwareCursor = process.env.PI_HARDWARE_CURSOR === "1";
 	private clearOnShrink = process.env.PI_CLEAR_ON_SHRINK === "1"; // Clear empty rows when content shrinks (default: off)
+	private readonly safeRenderMode = detectSafeRenderMode();
+	private readonly lineReset = this.safeRenderMode ? "\x1b[0m" : TUI.SEGMENT_RESET;
 	private maxLinesRendered = 0; // Track terminal's working area (max lines ever rendered)
 	private previousViewportTop = 0; // Track previous viewport top for resize-aware cursor moves
 	private fullRedrawCount = 0;
@@ -755,8 +768,16 @@ export class TUI extends Container {
 
 	private static readonly SEGMENT_RESET = "\x1b[0m\x1b]8;;\x07";
 
+	private beginSynchronizedOutput(): string {
+		return this.safeRenderMode ? "" : "\x1b[?2026h";
+	}
+
+	private endSynchronizedOutput(): string {
+		return this.safeRenderMode ? "" : "\x1b[?2026l";
+	}
+
 	private applyLineResets(lines: string[]): string[] {
-		const reset = TUI.SEGMENT_RESET;
+		const reset = this.lineReset;
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i];
 			if (!isImageLine(line)) {
@@ -792,7 +813,7 @@ export class TUI extends Container {
 		const afterPad = Math.max(0, afterTarget - base.afterWidth);
 
 		// Compose result
-		const r = TUI.SEGMENT_RESET;
+		const r = this.lineReset;
 		const result =
 			base.before +
 			" ".repeat(beforePad) +
@@ -877,13 +898,13 @@ export class TUI extends Container {
 		// Helper to clear scrollback and viewport and render all new lines
 		const fullRender = (clear: boolean): void => {
 			this.fullRedrawCount += 1;
-			let buffer = "\x1b[?2026h"; // Begin synchronized output
+			let buffer = this.beginSynchronizedOutput();
 			if (clear) buffer += "\x1b[3J\x1b[2J\x1b[H"; // Clear scrollback, screen, and home
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";
 				buffer += newLines[i];
 			}
-			buffer += "\x1b[?2026l"; // End synchronized output
+			buffer += this.endSynchronizedOutput();
 			this.terminal.write(buffer);
 			this.cursorRow = Math.max(0, newLines.length - 1);
 			this.hardwareCursorRow = this.cursorRow;
@@ -964,7 +985,7 @@ export class TUI extends Container {
 		// All changes are in deleted lines (nothing to render, just clear)
 		if (firstChanged >= newLines.length) {
 			if (this.previousLines.length > newLines.length) {
-				let buffer = "\x1b[?2026h";
+				let buffer = this.beginSynchronizedOutput();
 				// Move to end of new content (clamp to 0 for empty content)
 				const targetRow = Math.max(0, newLines.length - 1);
 				const lineDiff = computeLineDiff(targetRow);
@@ -988,7 +1009,7 @@ export class TUI extends Container {
 				if (extraLines > 0) {
 					buffer += `\x1b[${extraLines}A`;
 				}
-				buffer += "\x1b[?2026l";
+				buffer += this.endSynchronizedOutput();
 				this.terminal.write(buffer);
 				this.cursorRow = targetRow;
 				this.hardwareCursorRow = targetRow;
@@ -1012,7 +1033,7 @@ export class TUI extends Container {
 
 		// Render from first changed line to end
 		// Build buffer with all updates wrapped in synchronized output
-		let buffer = "\x1b[?2026h"; // Begin synchronized output
+		let buffer = this.beginSynchronizedOutput();
 		const prevViewportBottom = prevViewportTop + height - 1;
 		const moveTargetRow = appendStart ? firstChanged - 1 : firstChanged;
 		if (moveTargetRow > prevViewportBottom) {
@@ -1096,7 +1117,7 @@ export class TUI extends Container {
 			buffer += `\x1b[${extraLines}A`;
 		}
 
-		buffer += "\x1b[?2026l"; // End synchronized output
+		buffer += this.endSynchronizedOutput();
 
 		if (process.env.PI_TUI_DEBUG === "1") {
 			const debugDir = "/tmp/tui";

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -12,6 +12,68 @@ class TestComponent implements Component {
 	invalidate(): void {}
 }
 
+class RecordingTerminal {
+	public writes: string[] = [];
+	private _columns: number;
+	private _rows: number;
+
+	constructor(columns = 80, rows = 24) {
+		this._columns = columns;
+		this._rows = rows;
+	}
+
+	start(_onInput: (data: string) => void, _onResize: () => void): void {}
+	stop(): void {}
+	async drainInput(_maxMs?: number, _idleMs?: number): Promise<void> {}
+	write(data: string): void {
+		this.writes.push(data);
+	}
+	get columns(): number {
+		return this._columns;
+	}
+	get rows(): number {
+		return this._rows;
+	}
+	get kittyProtocolActive(): boolean {
+		return false;
+	}
+	moveBy(_lines: number): void {}
+	hideCursor(): void {}
+	showCursor(): void {}
+	clearLine(): void {}
+	clearFromCursor(): void {}
+	clearScreen(): void {}
+	setTitle(_title: string): void {}
+}
+
+async function waitForRender(): Promise<void> {
+	return new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+async function withTemporaryEnv(updates: Record<string, string | undefined>, fn: () => Promise<void>): Promise<void> {
+	const original: Record<string, string | undefined> = {};
+	for (const [key, value] of Object.entries(updates)) {
+		original[key] = process.env[key];
+		if (value === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = value;
+		}
+	}
+
+	try {
+		await fn();
+	} finally {
+		for (const [key, value] of Object.entries(original)) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	}
+}
+
 function getCellItalic(terminal: VirtualTerminal, row: number, col: number): number {
 	const xterm = (terminal as unknown as { xterm: XtermTerminalType }).xterm;
 	const buffer = xterm.buffer.active;
@@ -43,6 +105,59 @@ describe("TUI resize handling", () => {
 		assert.ok(tui.fullRedraws > initialRedraws, "Width change should trigger full redraw");
 
 		tui.stop();
+	});
+});
+
+describe("TUI safe render mode", () => {
+	it("uses a defensive render path by default on Apple Terminal", async () => {
+		await withTemporaryEnv(
+			{
+				TERM_PROGRAM: "Apple_Terminal",
+				PI_TUI_SAFE_MODE: undefined,
+			},
+			async () => {
+				const terminal = new RecordingTerminal(40, 10);
+				const tui = new TUI(terminal);
+				const component = new TestComponent();
+				component.lines = ["/skill 한글 입력"];
+				tui.addChild(component);
+
+				tui.start();
+				await waitForRender();
+				tui.stop();
+
+				const output = terminal.writes.join("");
+				assert.ok(!output.includes("\x1b[?2026h"));
+				assert.ok(!output.includes("\x1b[?2026l"));
+				assert.ok(!output.includes("\x1b]8;;\x07"));
+				assert.ok(output.includes("/skill 한글 입력"));
+			},
+		);
+	});
+
+	it("can force legacy render path on Apple Terminal via PI_TUI_SAFE_MODE=0", async () => {
+		await withTemporaryEnv(
+			{
+				TERM_PROGRAM: "Apple_Terminal",
+				PI_TUI_SAFE_MODE: "0",
+			},
+			async () => {
+				const terminal = new RecordingTerminal(40, 10);
+				const tui = new TUI(terminal);
+				const component = new TestComponent();
+				component.lines = ["legacy render test"];
+				tui.addChild(component);
+
+				tui.start();
+				await waitForRender();
+				tui.stop();
+
+				const output = terminal.writes.join("");
+				assert.ok(output.includes("\x1b[?2026h"));
+				assert.ok(output.includes("\x1b[?2026l"));
+				assert.ok(output.includes("\x1b]8;;\x07"));
+			},
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary
- isolate the Terminal.app crash trigger to high-frequency control-sequence rendering during IME-heavy input paths
- add an Apple Terminal safe-render fallback in TUI (auto-enabled on )
- in safe mode, disable synchronized output wrappers and OSC-8 reset suffixes while preserving normal rendering behavior
- add regression coverage for safe mode default and explicit override via 

## Verification
- ▶ StdinBuffer
  ▶ Regular Characters
    ✔ should pass through regular characters immediately (1.874295ms)
    ✔ should pass through multiple regular characters (0.19509ms)
    ✔ should handle unicode characters (0.17996ms)
  ✔ Regular Characters (2.832957ms)
  ▶ Complete Escape Sequences
    ✔ should pass through complete mouse SGR sequences (0.368431ms)
    ✔ should pass through complete arrow key sequences (0.20902ms)
    ✔ should pass through complete function key sequences (0.158331ms)
    ✔ should pass through meta key sequences (0.16104ms)
    ✔ should pass through SS3 sequences (0.14033ms)
  ✔ Complete Escape Sequences (1.310994ms)
  ▶ Partial Escape Sequences
    ✔ should buffer incomplete mouse SGR sequence (0.657112ms)
    ✔ should buffer incomplete CSI sequence (0.211951ms)
    ✔ should buffer split across many chunks (0.25278ms)
    ✔ should flush incomplete sequence after timeout (14.79546ms)
  ✔ Partial Escape Sequences (16.122443ms)
  ▶ Mixed Content
    ✔ should handle characters followed by escape sequence (0.14681ms)
    ✔ should handle escape sequence followed by characters (0.101681ms)
    ✔ should handle multiple complete sequences (0.09793ms)
    ✔ should handle partial sequence with preceding characters (0.14478ms)
  ✔ Mixed Content (0.605982ms)
  ▶ Kitty Keyboard Protocol
    ✔ should handle Kitty CSI u press events (0.15998ms)
    ✔ should handle Kitty CSI u release events (0.1027ms)
    ✔ should handle batched Kitty press and release (0.091251ms)
    ✔ should handle multiple batched Kitty events (0.09989ms)
    ✔ should handle Kitty arrow keys with event type (0.0871ms)
    ✔ should handle Kitty functional keys with event type (0.136841ms)
    ✔ should handle plain characters mixed with Kitty sequences (0.11424ms)
    ✔ should handle Kitty sequence followed by plain characters (0.10356ms)
    ✔ should handle rapid typing simulation with Kitty protocol (0.144731ms)
  ✔ Kitty Keyboard Protocol (1.251883ms)
  ▶ Mouse Events
    ✔ should handle mouse press event (0.16888ms)
    ✔ should handle mouse release event (0.105281ms)
    ✔ should handle mouse move event (0.13265ms)
    ✔ should handle split mouse events (0.148831ms)
    ✔ should handle multiple mouse events (0.11646ms)
    ✔ should handle old-style mouse sequence (ESC[M + 3 bytes) (0.14006ms)
    ✔ should buffer incomplete old-style mouse sequence (0.122031ms)
  ✔ Mouse Events (1.122943ms)
  ▶ Edge Cases
    ✔ should handle empty input (0.184321ms)
    ✔ should handle lone escape character with timeout (14.593778ms)
    ✔ should handle lone escape character with explicit flush (0.192201ms)
    ✔ should handle buffer input (0.15349ms)
    ✔ should decode split UTF-8 buffer chunks for Hangul input (0.198771ms)
    ✔ should decode mixed ASCII and Hangul from split UTF-8 buffer chunks (0.16329ms)
    ✔ should handle very long sequences (0.148481ms)
  ✔ Edge Cases (15.846282ms)
  ▶ Flush
    ✔ should flush incomplete sequences (0.15045ms)
    ✔ should return empty array if nothing to flush (0.086941ms)
    ✔ should emit flushed data via timeout (14.719149ms)
  ✔ Flush (15.10314ms)
  ▶ Clear
    ✔ should clear buffered content without emitting (0.189771ms)
  ✔ Clear (0.248901ms)
  ▶ Bracketed Paste
    ✔ should emit paste event for complete bracketed paste (0.2257ms)
    ✔ should handle paste arriving in chunks (0.13397ms)
    ✔ should handle paste with input before and after (0.14844ms)
    ✔ should handle paste with newlines (0.112761ms)
    ✔ should handle paste with unicode (0.109ms)
  ✔ Bracketed Paste (0.849872ms)
  ▶ Destroy
    ✔ should clear buffer on destroy (0.12008ms)
    ✔ should clear pending timeouts on destroy (14.669659ms)
  ✔ Destroy (14.877789ms)
✔ StdinBuffer (71.014248ms)
▶ TUI resize handling
  ✔ triggers full re-render when terminal width changes (12.027721ms)
✔ TUI resize handling (12.778933ms)
▶ TUI safe render mode
  ✔ uses a defensive render path by default on Apple Terminal (2.753527ms)
  ✔ can force legacy render path on Apple Terminal via PI_TUI_SAFE_MODE=0 (0.725092ms)
✔ TUI safe render mode (3.656249ms)
▶ TUI content shrinkage
  ✔ clears empty rows when content shrinks significantly (3.071029ms)
  ✔ handles shrink to single line (2.566106ms)
  ✔ handles shrink to empty (3.387169ms)
✔ TUI content shrinkage (9.303105ms)
▶ TUI differential rendering
  ✔ tracks cursor correctly when content shrinks with unchanged remaining lines (3.56269ms)
  ✔ renders correctly when only a middle line changes (spinner case) (6.713148ms)
  ✔ resets styles after each rendered line (1.010603ms)
  ✔ renders correctly when first line changes but rest stays same (3.088888ms)
  ✔ renders correctly when last line changes but rest stays same (3.216458ms)
  ✔ renders correctly when multiple non-adjacent lines change (3.116788ms)
  ✔ handles transition from content to empty and back to content (4.038121ms)
✔ TUI differential rendering (25.167457ms)
ℹ tests 63
ℹ suites 16
ℹ pass 63
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 309.575339
- 
> pi-monorepo@0.0.3 check
> biome check --write --error-on-warnings . && tsgo --noEmit && cd packages/web-ui && npm run check

Checked 488 files in 225ms. No fixes applied.

> @mariozechner/pi-web-ui@0.55.4 check
> biome check --write --error-on-warnings . && tsc --noEmit && cd example && biome check --write --error-on-warnings . && tsc --noEmit

Checked 73 files in 26ms. No fixes applied.
Checked 3 files in 9ms. No fixes applied.

Closes #9