### PR TITLE
fix: prevent mixed-width overflow in footer/select-list

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -26,6 +26,68 @@ function formatTokens(count: number): string {
 	return `${Math.round(count / 1000000)}M`;
 }
 
+const ansiRegex = /\x1b\[[0-9;]*m/g;
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+function stripAnsi(text: string): string {
+	return text.replace(ansiRegex, "");
+}
+
+function truncateMiddleToWidth(text: string, maxWidth: number, ellipsis = "..."): string {
+	if (maxWidth <= 0) {
+		return "";
+	}
+	if (visibleWidth(text) <= maxWidth) {
+		return text;
+	}
+
+	const ellipsisWidth = visibleWidth(ellipsis);
+	if (ellipsisWidth >= maxWidth) {
+		return truncateToWidth(ellipsis, maxWidth, "");
+	}
+
+	const availableWidth = maxWidth - ellipsisWidth;
+	const segments = Array.from(graphemeSegmenter.segment(text), ({ segment }) => segment);
+
+	let startText = "";
+	let endText = "";
+	let startWidth = 0;
+	let endWidth = 0;
+	let left = 0;
+	let right = segments.length - 1;
+
+	while (left <= right) {
+		const takeStart = startWidth <= endWidth;
+		if (takeStart) {
+			const segment = segments[left];
+			if (!segment) {
+				break;
+			}
+			const segmentWidth = visibleWidth(segment);
+			if (startWidth + endWidth + segmentWidth > availableWidth) {
+				break;
+			}
+			startText += segment;
+			startWidth += segmentWidth;
+			left += 1;
+		} else {
+			const segment = segments[right];
+			if (!segment) {
+				break;
+			}
+			const segmentWidth = visibleWidth(segment);
+			if (startWidth + endWidth + segmentWidth > availableWidth) {
+				break;
+			}
+			endText = segment + endText;
+			endWidth += segmentWidth;
+			right -= 1;
+		}
+	}
+
+	return `${startText}${ellipsis}${endText}`;
+}
+
 /**
  * Footer component that shows pwd, token stats, and context usage.
  * Computes token/context stats from session, gets git branch and extension statuses from provider.
@@ -105,15 +167,8 @@ export class FooterComponent implements Component {
 		}
 
 		// Truncate path if too long to fit width
-		if (pwd.length > width) {
-			const half = Math.floor(width / 2) - 2;
-			if (half > 1) {
-				const start = pwd.slice(0, half);
-				const end = pwd.slice(-(half - 1));
-				pwd = `${start}...${end}`;
-			} else {
-				pwd = pwd.slice(0, Math.max(1, width));
-			}
+		if (visibleWidth(pwd) > width) {
+			pwd = truncateMiddleToWidth(pwd, width);
 		}
 
 		// Build stats line
@@ -156,8 +211,8 @@ export class FooterComponent implements Component {
 		// If statsLeft is too wide, truncate it
 		if (statsLeftWidth > width) {
 			// Truncate statsLeft to fit width (no room for right side)
-			const plainStatsLeft = statsLeft.replace(/\x1b\[[0-9;]*m/g, "");
-			statsLeft = `${plainStatsLeft.substring(0, width - 3)}...`;
+			const plainStatsLeft = stripAnsi(statsLeft);
+			statsLeft = truncateToWidth(plainStatsLeft, width, "...");
 			statsLeftWidth = visibleWidth(statsLeft);
 		}
 
@@ -193,13 +248,13 @@ export class FooterComponent implements Component {
 		} else {
 			// Need to truncate right side
 			const availableForRight = width - statsLeftWidth - minPadding;
-			if (availableForRight > 3) {
-				// Truncate to fit (strip ANSI codes for length calculation, then truncate raw string)
-				const plainRightSide = rightSide.replace(/\x1b\[[0-9;]*m/g, "");
-				const truncatedPlain = plainRightSide.substring(0, availableForRight);
-				// For simplicity, just use plain truncated version (loses color, but fits)
-				const padding = " ".repeat(width - statsLeftWidth - truncatedPlain.length);
-				statsLine = statsLeft + padding + truncatedPlain;
+			if (availableForRight > 0) {
+				// Truncate to fit (strip ANSI codes first; right side is plain text anyway)
+				const plainRightSide = stripAnsi(rightSide);
+				const truncatedRight = truncateToWidth(plainRightSide, availableForRight, "");
+				const truncatedRightWidth = visibleWidth(truncatedRight);
+				const padding = " ".repeat(Math.max(minPadding, width - statsLeftWidth - truncatedRightWidth));
+				statsLine = statsLeft + padding + truncatedRight;
 			} else {
 				// Not enough space for right side at all
 				statsLine = statsLeft;

--- a/packages/coding-agent/test/footer-width-regression.test.ts
+++ b/packages/coding-agent/test/footer-width-regression.test.ts
@@ -1,0 +1,87 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { visibleWidth } from "@mariozechner/pi-tui";
+import { beforeAll, describe, expect, test } from "vitest";
+import type { AgentSession } from "../src/core/agent-session.js";
+import type { ReadonlyFooterDataProvider } from "../src/core/footer-data-provider.js";
+import { FooterComponent } from "../src/modes/interactive/components/footer.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+function createSessionStub(modelId: string): AgentSession {
+	return {
+		state: {
+			model: {
+				id: modelId,
+				provider: "openai",
+				reasoning: true,
+				contextWindow: 200_000,
+			},
+			thinkingLevel: "high",
+		},
+		sessionManager: {
+			getEntries: () => [
+				{
+					type: "message",
+					message: {
+						role: "assistant",
+						usage: {
+							input: 52_000,
+							output: 17_000,
+							cacheRead: 3_000,
+							cacheWrite: 2_000,
+							cost: { total: Math.PI },
+						},
+					},
+				},
+			],
+			getSessionName: () => "세션-테스트",
+		},
+		getContextUsage: () => ({
+			contextWindow: 200_000,
+			percent: 91.7,
+		}),
+		modelRegistry: {
+			isUsingOAuth: () => false,
+		},
+	} as unknown as AgentSession;
+}
+
+function createFooterDataStub(): ReadonlyFooterDataProvider {
+	return {
+		getGitBranch: () => "feature/한글-branch-name",
+		getExtensionStatuses: () => new Map(),
+		getAvailableProviderCount: () => 2,
+		onBranchChange: () => () => {},
+	};
+}
+
+describe("Footer width regressions", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("keeps mixed-width path and status lines within terminal width", () => {
+		const originalCwd = process.cwd();
+		const tempRoot = mkdtempSync(join(tmpdir(), "pi-footer-width-"));
+		const nestedDir = join(tempRoot, "workspace-한글-경로-길이-테스트", "subdir");
+		mkdirSync(nestedDir, { recursive: true });
+		process.chdir(nestedDir);
+
+		try {
+			const footer = new FooterComponent(
+				createSessionStub("gpt-5-한글-모델-super-long-name"),
+				createFooterDataStub(),
+			);
+			const width = 44;
+			const lines = footer.render(width);
+
+			expect(lines.length).toBeGreaterThanOrEqual(2);
+			expect(visibleWidth(lines[0] ?? "")).toBeLessThanOrEqual(width);
+			expect(visibleWidth(lines[1] ?? "")).toBeLessThanOrEqual(width);
+		} finally {
+			process.chdir(originalCwd);
+			rmSync(tempRoot, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -1,6 +1,6 @@
 import { getEditorKeybindings } from "../keybindings.js";
 import type { Component } from "../tui.js";
-import { truncateToWidth } from "../utils.js";
+import { truncateToWidth, visibleWidth } from "../utils.js";
 
 const normalizeToSingleLine = (text: string): string => text.replace(/[\r\n]+/g, " ").trim();
 
@@ -77,17 +77,19 @@ export class SelectList implements Component {
 			let line = "";
 			if (isSelected) {
 				// Use arrow indicator for selection - entire line uses selectedText color
-				const prefixWidth = 2; // "→ " is 2 characters visually
+				const prefixWidth = visibleWidth("→ ");
 				const displayValue = item.label || item.value;
 
 				if (descriptionSingleLine && width > 40) {
 					// Calculate how much space we have for value + description
-					const maxValueWidth = Math.min(30, width - prefixWidth - 4);
+					const maxValueWidth = Math.max(1, Math.min(30, width - prefixWidth - 4));
 					const truncatedValue = truncateToWidth(displayValue, maxValueWidth, "");
-					const spacing = " ".repeat(Math.max(1, 32 - truncatedValue.length));
+					const truncatedValueWidth = visibleWidth(truncatedValue);
+					const spacingWidth = Math.max(1, 32 - truncatedValueWidth);
+					const spacing = " ".repeat(spacingWidth);
 
 					// Calculate remaining space for description using visible widths
-					const descriptionStart = prefixWidth + truncatedValue.length + spacing.length;
+					const descriptionStart = prefixWidth + truncatedValueWidth + spacingWidth;
 					const remainingWidth = width - descriptionStart - 2; // -2 for safety
 
 					if (remainingWidth > 10) {
@@ -107,15 +109,18 @@ export class SelectList implements Component {
 			} else {
 				const displayValue = item.label || item.value;
 				const prefix = "  ";
+				const prefixWidth = visibleWidth(prefix);
 
 				if (descriptionSingleLine && width > 40) {
 					// Calculate how much space we have for value + description
-					const maxValueWidth = Math.min(30, width - prefix.length - 4);
+					const maxValueWidth = Math.max(1, Math.min(30, width - prefixWidth - 4));
 					const truncatedValue = truncateToWidth(displayValue, maxValueWidth, "");
-					const spacing = " ".repeat(Math.max(1, 32 - truncatedValue.length));
+					const truncatedValueWidth = visibleWidth(truncatedValue);
+					const spacingWidth = Math.max(1, 32 - truncatedValueWidth);
+					const spacing = " ".repeat(spacingWidth);
 
 					// Calculate remaining space for description
-					const descriptionStart = prefix.length + truncatedValue.length + spacing.length;
+					const descriptionStart = prefixWidth + truncatedValueWidth + spacingWidth;
 					const remainingWidth = width - descriptionStart - 2; // -2 for safety
 
 					if (remainingWidth > 10) {
@@ -124,12 +129,12 @@ export class SelectList implements Component {
 						line = prefix + truncatedValue + descText;
 					} else {
 						// Not enough space for description
-						const maxWidth = width - prefix.length - 2;
+						const maxWidth = width - prefixWidth - 2;
 						line = prefix + truncateToWidth(displayValue, maxWidth, "");
 					}
 				} else {
 					// No description or not enough width
-					const maxWidth = width - prefix.length - 2;
+					const maxWidth = width - prefixWidth - 2;
 					line = prefix + truncateToWidth(displayValue, maxWidth, "");
 				}
 			}

--- a/packages/tui/test/select-list.test.ts
+++ b/packages/tui/test/select-list.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import { SelectList } from "../src/components/select-list.js";
+import { visibleWidth } from "../src/utils.js";
 
 const testTheme = {
 	selectedPrefix: (text: string) => text,
@@ -26,5 +27,55 @@ describe("SelectList", () => {
 		assert.ok(rendered.length > 0);
 		assert.ok(!rendered[0].includes("\n"));
 		assert.ok(rendered[0].includes("Line one Line two Line three"));
+	});
+
+	it("keeps mixed-width slash suggestion rows within terminal width", () => {
+		const items = [
+			{
+				value: "/한글",
+				label: "/한글",
+				description: "한글 IME suggestion with mixed-width 값 and ascii",
+			},
+			{
+				value: "/slash",
+				label: "/slash",
+				description: "ASCII fallback description",
+			},
+		];
+
+		const list = new SelectList(items, 5, testTheme);
+		const width = 46;
+		const rendered = list.render(width);
+
+		assert.ok(rendered.length >= 2);
+		for (const line of rendered) {
+			assert.ok(visibleWidth(line) <= width, `line exceeds width ${width}: "${line}"`);
+		}
+	});
+
+	it("keeps slash+hangul filtered suggestions within width", () => {
+		const items = [
+			{
+				value: "/ㅎ한글",
+				label: "/ㅎ한글",
+				description: "한글 조합 중 slash suggestion overflow regression",
+			},
+			{
+				value: "/help",
+				label: "/help",
+				description: "help command",
+			},
+		];
+
+		const list = new SelectList(items, 5, testTheme);
+		list.setFilter("/ㅎ");
+
+		const width = 44;
+		const rendered = list.render(width);
+
+		assert.ok(rendered.length > 0);
+		for (const line of rendered) {
+			assert.ok(visibleWidth(line) <= width, `line exceeds width ${width}: "${line}"`);
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- Replace .length-based width math with visibleWidth in footer/select-list rendering paths.
- Make footer truncation width-safe for mixed-width cwd/session/model text.
- Add regressions for mixed-width footer rendering and slash+Hangul suggestion rendering.

## Verification
- node --test --import tsx test/select-list.test.ts (packages/tui)
- npx tsx ../../node_modules/vitest/dist/cli.js --run test/footer-width-regression.test.ts (packages/coding-agent)
- npm run check

Closes #12