### PR TITLE
feat: phase-1 multi-agent foundation (ipc + routing + task delegation)

### DIFF
--- a/extensions/multi-agent/README.md
+++ b/extensions/multi-agent/README.md
@@ -1,0 +1,23 @@
+# @pi/multi-agent
+
+Phase-1 multi-agent foundation extension.
+
+## Included in this slice
+
+- Agent registry and built-in agent factories (`sisyphus`, `sisyphus-junior`, `oracle`, `explore`)
+- Category/model routing via `ModelRouter`
+- `task` tool for in-process sub-agent delegation via `ctx.runSubAgent`
+- Lightweight dynamic prompt builder for orchestrator prompts
+
+## Settings
+
+This extension reads `multiAgent` from:
+
+- `~/.pi/agent/settings.json`
+- `<project>/.pi/settings.json`
+
+Project settings override global settings.
+
+## Runtime requirement
+
+The host session must expose `ctx.runSubAgent` (added in this slice to `AgentSession`).

--- a/extensions/multi-agent/package.json
+++ b/extensions/multi-agent/package.json
@@ -1,0 +1,38 @@
+{
+	"name": "@pi/multi-agent",
+	"version": "0.55.4",
+	"description": "Multi-agent orchestration extension for pi",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"scripts": {
+		"clean": "rm -rf dist",
+		"build": "tsgo -p tsconfig.build.json",
+		"dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
+		"test": "vitest --run"
+	},
+	"dependencies": {
+		"@mariozechner/pi-ai": "^0.55.4",
+		"@mariozechner/pi-coding-agent": "^0.55.4",
+		"@mariozechner/pi-ipc": "^0.55.4",
+		"@sinclair/typebox": "^0.34.41"
+	},
+	"devDependencies": {
+		"@types/node": "^24.3.0",
+		"typescript": "^5.7.3",
+		"vitest": "^3.2.4"
+	},
+	"pi": {
+		"extensions": ["./dist/index.js"]
+	}
+}

--- a/extensions/multi-agent/src/agents/explore.ts
+++ b/extensions/multi-agent/src/agents/explore.ts
@@ -1,0 +1,13 @@
+import type { AgentConfig, AgentFactory } from "../registry/types.js";
+
+export const exploreFactory: AgentFactory = Object.assign(
+	(model: string): AgentConfig => ({
+		name: "explore",
+		description: "Codebase exploration specialist.",
+		whenToUse: "Use for broad repository scans and dependency tracing.",
+		systemPrompt: `You are Explore. Map relevant code quickly and accurately. Active model: ${model}.`,
+		tools: ["find", "grep", "read", "ls"],
+		defaultThinkingLevel: "low",
+	}),
+	{ mode: "subagent" as const },
+);

--- a/extensions/multi-agent/src/agents/index.ts
+++ b/extensions/multi-agent/src/agents/index.ts
@@ -1,0 +1,13 @@
+import { createSisyphusFactory } from "./sisyphus.js";
+import { sisyphusJuniorFactory } from "./sisyphus-junior.js";
+import { oracleFactory } from "./oracle.js";
+import { exploreFactory } from "./explore.js";
+import type { DynamicPromptBuilder } from "../prompts/DynamicPromptBuilder.js";
+import type { AgentRegistry } from "../registry/AgentRegistry.js";
+
+export function registerBuiltInAgents(registry: AgentRegistry, promptBuilder: DynamicPromptBuilder): void {
+	registry.register("sisyphus", createSisyphusFactory(promptBuilder), "multi-agent");
+	registry.register("sisyphus-junior", sisyphusJuniorFactory, "multi-agent");
+	registry.register("oracle", oracleFactory, "multi-agent");
+	registry.register("explore", exploreFactory, "multi-agent");
+}

--- a/extensions/multi-agent/src/agents/oracle.ts
+++ b/extensions/multi-agent/src/agents/oracle.ts
@@ -1,0 +1,13 @@
+import type { AgentConfig, AgentFactory } from "../registry/types.js";
+
+export const oracleFactory: AgentFactory = Object.assign(
+	(model: string): AgentConfig => ({
+		name: "oracle",
+		description: "Read-oriented advisor for architecture and reasoning checks.",
+		whenToUse: "Use for analysis, planning, and risk review with minimal edits.",
+		systemPrompt: `You are Oracle. Focus on analysis, risks, and recommendations. Active model: ${model}.`,
+		tools: ["read", "find", "grep", "ls"],
+		defaultThinkingLevel: "high",
+	}),
+	{ mode: "subagent" as const },
+);

--- a/extensions/multi-agent/src/agents/sisyphus-junior.ts
+++ b/extensions/multi-agent/src/agents/sisyphus-junior.ts
@@ -1,0 +1,35 @@
+import type { AgentConfig, AgentFactory } from "../registry/types.js";
+
+function buildPrompt(model: string): string {
+	const provider = model.split("/")[0] ?? "anthropic";
+	if (provider === "google" || provider === "google-vertex") {
+		return [
+			"You are Sisyphus-Junior, a concise execution specialist.",
+			"Prefer deterministic edits, small diffs, and explicit verification.",
+			"Use tools only when necessary and report concrete outcomes.",
+		].join("\n");
+	}
+	if (provider === "openai") {
+		return [
+			"You are Sisyphus-Junior, an implementation specialist.",
+			"Optimize for accurate tool usage and explicit assumptions.",
+			"Produce final summaries with changed files and validation status.",
+		].join("\n");
+	}
+	return [
+		"You are Sisyphus-Junior, a reliable coding execution agent.",
+		"Favor safe incremental changes and concise status updates.",
+	].join("\n");
+}
+
+export const sisyphusJuniorFactory: AgentFactory = Object.assign(
+	(model: string): AgentConfig => ({
+		name: "sisyphus-junior",
+		description: "General-purpose execution sub-agent.",
+		whenToUse: "Default delegate for uncategorized or medium-complexity coding tasks.",
+		systemPrompt: buildPrompt(model),
+		tools: ["read", "bash", "edit", "write", "grep", "find", "ls"],
+		defaultThinkingLevel: "medium",
+	}),
+	{ mode: "all" as const },
+);

--- a/extensions/multi-agent/src/agents/sisyphus.ts
+++ b/extensions/multi-agent/src/agents/sisyphus.ts
@@ -1,0 +1,20 @@
+import { DynamicPromptBuilder } from "../prompts/DynamicPromptBuilder.js";
+import type { AgentConfig, AgentFactory } from "../registry/types.js";
+
+const basePrompt = `You are Sisyphus, the primary orchestrator.
+Use task() for focused sub-work when delegation improves quality, safety, or speed.
+Always keep the user informed about delegated intent and returned results.`;
+
+export function createSisyphusFactory(promptBuilder: DynamicPromptBuilder): AgentFactory {
+	return Object.assign(
+		(model: string): AgentConfig => ({
+			name: "sisyphus",
+			description: "Primary orchestrator coordinating specialist sub-agents.",
+			whenToUse: "Use for user-facing planning, decomposition, and synthesis.",
+			systemPrompt: promptBuilder.buildOrchestratorPrompt(`${basePrompt}\nModel: ${model}`),
+			tools: ["read", "bash", "edit", "write", "grep", "find", "ls", "task"],
+			defaultThinkingLevel: "high",
+		}),
+		{ mode: "primary" as const },
+	);
+}

--- a/extensions/multi-agent/src/config.ts
+++ b/extensions/multi-agent/src/config.ts
@@ -1,0 +1,42 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import type { MultiAgentConfig } from "./routing/types.js";
+
+interface SettingsWithMultiAgent {
+	multiAgent?: MultiAgentConfig;
+}
+
+function readSettings(path: string): SettingsWithMultiAgent {
+	if (!existsSync(path)) {
+		return {};
+	}
+	try {
+		return JSON.parse(readFileSync(path, "utf8")) as SettingsWithMultiAgent;
+	} catch {
+		return {};
+	}
+}
+
+function mergeConfig(base: MultiAgentConfig, override: MultiAgentConfig | undefined): MultiAgentConfig {
+	if (!override) {
+		return base;
+	}
+	return {
+		...base,
+		...override,
+		agents: { ...(base.agents ?? {}), ...(override.agents ?? {}) },
+		categories: { ...(base.categories ?? {}), ...(override.categories ?? {}) },
+		providerKeys: { ...(base.providerKeys ?? {}), ...(override.providerKeys ?? {}) },
+	};
+}
+
+export function loadMultiAgentConfig(cwd: string): MultiAgentConfig {
+	const globalSettings = readSettings(join(getAgentDir(), "settings.json")).multiAgent;
+	const projectSettings = readSettings(join(cwd, ".pi", "settings.json")).multiAgent;
+	const merged = mergeConfig(mergeConfig({}, globalSettings), projectSettings);
+	if (merged.enabled === undefined) {
+		merged.enabled = true;
+	}
+	return merged;
+}

--- a/extensions/multi-agent/src/index.ts
+++ b/extensions/multi-agent/src/index.ts
@@ -1,0 +1,199 @@
+import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { registerBuiltInAgents } from "./agents/index.js";
+import { loadMultiAgentConfig } from "./config.js";
+import { TaskDelegator } from "./orchestration/TaskDelegator.js";
+import { DynamicPromptBuilder } from "./prompts/DynamicPromptBuilder.js";
+import { AgentRegistry } from "./registry/AgentRegistry.js";
+import { CategoryRouter } from "./routing/CategoryRouter.js";
+import { createBackgroundCancelTool, createBackgroundOutputTool } from "./tools/background-task-tool.js";
+import { createSharedStateTool } from "./tools/shared-state-tool.js";
+import { createTaskTool } from "./tools/task-tool.js";
+
+interface MultiAgentRuntime {
+	signature: string;
+	registry: AgentRegistry;
+	categoryRouter: CategoryRouter;
+	delegator: TaskDelegator;
+}
+
+const VALID_THINKING_LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh"];
+
+let runtime: MultiAgentRuntime | undefined;
+
+function parseThinkingLevel(input: string | undefined): ThinkingLevel | undefined {
+	if (!input) {
+		return undefined;
+	}
+	if (VALID_THINKING_LEVELS.includes(input as ThinkingLevel)) {
+		return input as ThinkingLevel;
+	}
+	throw new Error(`Invalid thinking level: ${input}`);
+}
+
+function buildRuntime(ctx: ExtensionContext): MultiAgentRuntime {
+	const config = loadMultiAgentConfig(ctx.cwd);
+	const signature = JSON.stringify(config);
+	if (runtime && runtime.signature === signature) {
+		return runtime;
+	}
+
+	const registry = new AgentRegistry();
+	const categoryRouter = new CategoryRouter();
+	const promptBuilder = new DynamicPromptBuilder(registry, categoryRouter);
+	registerBuiltInAgents(registry, promptBuilder);
+
+	for (const [name, agentConfig] of Object.entries(config.agents ?? {})) {
+		if (agentConfig.disabled) {
+			registry.setDisabled(name, true);
+		}
+	}
+
+	const delegator = new TaskDelegator(registry, categoryRouter, config, ctx);
+	const nextRuntime: MultiAgentRuntime = {
+		signature,
+		registry,
+		categoryRouter,
+		delegator,
+	};
+	runtime = nextRuntime;
+	return nextRuntime;
+}
+
+function splitArgs(raw: string): string[] {
+	return raw
+		.trim()
+		.split(/\s+/)
+		.filter((value) => value.length > 0);
+}
+
+function renderAgentList(ctx: ExtensionCommandContext): string {
+	const current = buildRuntime(ctx);
+	return current.registry
+		.list()
+		.map((agentName) => {
+			const metadata = current.registry.getMetadata(agentName);
+			if (!metadata) {
+				return `${agentName}`;
+			}
+			const defaultCategory = current.categoryRouter
+				.list()
+				.find((category) => category.defaultAgent === agentName)?.name;
+			return `${agentName} [${metadata.mode}]${defaultCategory ? ` category=${defaultCategory}` : ""} - ${metadata.description}`;
+		})
+		.join("\n");
+}
+
+function renderModelList(ctx: ExtensionCommandContext, provider?: string): string {
+	const models = ctx.modelRegistry
+		.getAvailable()
+		.filter((model) => (provider ? model.provider === provider : true))
+		.map((model) => `${model.provider}/${model.id}`)
+		.sort();
+	if (models.length === 0) {
+		return provider ? `No models available for provider ${provider}.` : "No models available.";
+	}
+	return models.join("\n");
+}
+
+async function renderResolvedAgent(ctx: ExtensionCommandContext, agentName: string, category?: string): Promise<string> {
+	const current = buildRuntime(ctx);
+	const resolved = await current.delegator.resolve(agentName, category);
+	const thinking = resolved.thinkingLevel ? ` thinking=${resolved.thinkingLevel}` : "";
+	return `${agentName} -> ${resolved.modelId} via ${resolved.resolvedVia}${thinking}`;
+}
+
+export default function multiAgentExtension(pi: ExtensionAPI): void {
+	pi.on("session_start", (_event, ctx) => {
+		buildRuntime(ctx);
+	});
+
+	pi.registerTool(createTaskTool((ctx) => buildRuntime(ctx).delegator));
+	pi.registerTool(createBackgroundOutputTool((ctx) => buildRuntime(ctx).delegator));
+	pi.registerTool(createBackgroundCancelTool((ctx) => buildRuntime(ctx).delegator));
+	pi.registerTool(createSharedStateTool());
+
+	pi.registerCommand("agents", {
+		description: "List registered multi-agent workers and defaults",
+		handler: async (_args, ctx) => {
+			const output = renderAgentList(ctx);
+			console.log(output);
+			if (ctx.hasUI) {
+				ctx.ui.notify("Printed multi-agent registry", "info");
+			}
+		},
+	});
+
+	pi.registerCommand("agent.get_model", {
+		description: "Resolve configured model for an agent",
+		handler: async (args, ctx) => {
+			const [agentName, category] = splitArgs(args);
+			if (!agentName) {
+				throw new Error("Usage: /agent.get_model <agentName> [category]");
+			}
+			console.log(await renderResolvedAgent(ctx, agentName, category));
+		},
+	});
+
+	pi.registerCommand("agent.set_model", {
+		description: "Set runtime model override for an agent",
+		handler: async (args, ctx) => {
+			const [agentName, model, thinkingLevelRaw] = splitArgs(args);
+			if (!agentName || !model) {
+				throw new Error("Usage: /agent.set_model <agentName> <provider/model> [thinkingLevel]");
+			}
+			const current = buildRuntime(ctx);
+			current.delegator.setModel(agentName, model, parseThinkingLevel(thinkingLevelRaw));
+			console.log(await renderResolvedAgent(ctx, agentName));
+		},
+	});
+
+	pi.registerCommand("agent.set_provider", {
+		description: "Set runtime provider override for an agent",
+		handler: async (args, ctx) => {
+			const [agentName, provider, thinkingLevelRaw] = splitArgs(args);
+			if (!agentName || !provider) {
+				throw new Error("Usage: /agent.set_provider <agentName> <provider> [thinkingLevel]");
+			}
+			const current = buildRuntime(ctx);
+			current.delegator.setProvider(agentName, provider, parseThinkingLevel(thinkingLevelRaw));
+			console.log(await renderResolvedAgent(ctx, agentName));
+		},
+	});
+
+	pi.registerCommand("agent.reset_model", {
+		description: "Reset runtime model override for an agent",
+		handler: async (args, ctx) => {
+			const [agentName] = splitArgs(args);
+			if (!agentName) {
+				throw new Error("Usage: /agent.reset_model <agentName>");
+			}
+			const current = buildRuntime(ctx);
+			current.delegator.resetModel(agentName);
+			console.log(await renderResolvedAgent(ctx, agentName));
+		},
+	});
+
+	pi.registerCommand("models", {
+		description: "List available models (optionally for one provider)",
+		handler: async (args, ctx) => {
+			const [provider] = splitArgs(args);
+			console.log(renderModelList(ctx, provider));
+		},
+	});
+}
+
+export { AgentRegistry } from "./registry/AgentRegistry.js";
+export type { AgentConfig, AgentFactory, AgentMode } from "./registry/types.js";
+export { CategoryRouter, DEFAULT_CATEGORIES } from "./routing/CategoryRouter.js";
+export { ModelRouter } from "./routing/ModelRouter.js";
+export type {
+	AgentModelConfig,
+	ModelCapability,
+	ModelChainEntry,
+	MultiAgentConfig,
+	ProviderKeyOverrides,
+	ResolvedModel,
+} from "./routing/types.js";
+export { TaskDelegator } from "./orchestration/TaskDelegator.js";
+export type { TaskDelegateParams, TaskDelegateResult } from "./orchestration/TaskDelegator.js";

--- a/extensions/multi-agent/src/orchestration/TaskDelegator.ts
+++ b/extensions/multi-agent/src/orchestration/TaskDelegator.ts
@@ -1,0 +1,260 @@
+import { randomUUID } from "node:crypto";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { AgentRegistry } from "../registry/AgentRegistry.js";
+import type { CategoryRouter } from "../routing/CategoryRouter.js";
+import { ModelRouter } from "../routing/ModelRouter.js";
+import type {
+	CategoryAgentMap,
+	MultiAgentConfig,
+	ResolvedModel,
+	RuntimeModelOverride,
+	ThinkingLevel,
+} from "../routing/types.js";
+
+export interface TaskDelegateParams {
+	prompt: string;
+	category?: string;
+	agent?: string;
+	session_id?: string;
+	run_in_background?: boolean;
+	load_skills?: string[];
+	max_prompt_tokens?: number;
+}
+
+interface ExecutionStrategy {
+	type: "agent" | "category";
+	agentName: string;
+	category?: string;
+	resolved: ResolvedModel;
+}
+
+interface BackgroundTaskHandle {
+	taskId: string;
+	sessionId: string;
+	status: "running" | "completed" | "failed" | "cancelled";
+	promise: Promise<TaskDelegateResult>;
+	cancelled: boolean;
+}
+
+export interface TaskDelegateResult {
+	session_id: string;
+	mode: "sync" | "background";
+	output?: string;
+	task_id?: string;
+	model_used: string;
+	agent_used: string;
+	metadata: {
+		started_at: string;
+		completed_at?: string;
+		token_usage?: { input: number; output: number };
+		resolved_via: string;
+	};
+}
+
+export class TaskDelegator {
+	private readonly modelRouter: ModelRouter;
+	private readonly categoryToAgent: CategoryAgentMap;
+	private readonly backgroundTasks = new Map<string, BackgroundTaskHandle>();
+
+	constructor(
+		private readonly registry: AgentRegistry,
+		private readonly categoryRouter: CategoryRouter,
+		config: MultiAgentConfig,
+		ctx: ExtensionContext,
+	) {
+		const categoryConfigs = {
+			...categoryRouter.toCategoryModelConfig(),
+			...(config.categories ?? {}),
+		};
+		this.modelRouter = ModelRouter.fromConfig(
+			{
+				...config,
+				categories: categoryConfigs,
+			},
+			ctx.modelRegistry,
+		);
+		this.categoryToAgent = categoryRouter.toCategoryAgentMap();
+	}
+
+	setModel(agentName: string, model: string, thinkingLevel?: ThinkingLevel): void {
+		this.modelRouter.setAgentModel(agentName, model, thinkingLevel);
+	}
+
+	setProvider(agentName: string, provider: string, thinkingLevel?: ThinkingLevel): void {
+		this.modelRouter.setAgentProvider(agentName, provider, thinkingLevel);
+	}
+
+	resetModel(agentName: string): void {
+		this.modelRouter.resetAgentModel(agentName);
+	}
+
+	getRuntimeOverride(agentName: string): RuntimeModelOverride | undefined {
+		return this.modelRouter.getRuntimeOverride(agentName);
+	}
+
+	async resolve(agentName: string, category?: string): Promise<ResolvedModel> {
+		return this.modelRouter.resolveForAgent(agentName, category);
+	}
+
+	async execute(params: TaskDelegateParams, ctx: ExtensionContext): Promise<TaskDelegateResult> {
+		const strategy = await this.resolveStrategy(params);
+		if (params.run_in_background) {
+			return this.executeBackground(params, strategy, ctx);
+		}
+		return this.executeSync(params, strategy, ctx);
+	}
+
+	getBackgroundTask(taskId: string): { status: BackgroundTaskHandle["status"]; result?: TaskDelegateResult } | undefined {
+		const handle = this.backgroundTasks.get(taskId);
+		if (!handle) {
+			return undefined;
+		}
+		if (handle.status === "completed" || handle.status === "failed") {
+			return {
+				status: handle.status,
+			};
+		}
+		return { status: handle.status };
+	}
+
+	cancelBackgroundTask(taskId: string): boolean {
+		const handle = this.backgroundTasks.get(taskId);
+		if (!handle || handle.status !== "running") {
+			return false;
+		}
+		handle.cancelled = true;
+		handle.status = "cancelled";
+		return true;
+	}
+
+	private async resolveStrategy(params: TaskDelegateParams): Promise<ExecutionStrategy> {
+		if (params.agent) {
+			const factory = this.registry.get(params.agent);
+			if (!factory) {
+				throw new Error(`Unknown agent: ${params.agent}`);
+			}
+			if (factory.mode === "primary") {
+				throw new Error(`Agent ${params.agent} cannot be called via task(); mode=${factory.mode}`);
+			}
+			const resolved = await this.modelRouter.resolveForAgent(params.agent, params.category);
+			return {
+				type: "agent",
+				agentName: params.agent,
+				resolved,
+			};
+		}
+
+		if (params.category) {
+			const agentName = this.categoryToAgent[params.category] ?? "sisyphus-junior";
+			const resolved =
+				(await this.modelRouter.resolveForCategory(params.category, agentName)) ??
+				(await this.modelRouter.resolveForAgent(agentName, params.category));
+			return {
+				type: "category",
+				category: params.category,
+				agentName: resolved.agentName,
+				resolved,
+			};
+		}
+
+		const resolved = await this.modelRouter.resolveForAgent("sisyphus-junior", "unspecified-low");
+		return {
+			type: "category",
+			category: "unspecified-low",
+			agentName: "sisyphus-junior",
+			resolved,
+		};
+	}
+
+	private async executeSync(
+		params: TaskDelegateParams,
+		strategy: ExecutionStrategy,
+		ctx: ExtensionContext,
+	): Promise<TaskDelegateResult> {
+		if (!ctx.runSubAgent) {
+			throw new Error("This runtime does not support runSubAgent(). Update to a compatible pi-coding-agent build.");
+		}
+
+		const sessionId = params.session_id ?? `ses_${randomUUID()}`;
+		const startedAt = new Date().toISOString();
+		const agentConfig = this.registry.instantiate(strategy.agentName, strategy.resolved.modelId);
+		const prompt = this.applySkillPrelude(params.prompt, params.load_skills);
+
+		const result = await ctx.runSubAgent({
+			agentName: strategy.agentName,
+			sessionId,
+			systemPrompt: agentConfig.systemPrompt,
+			model: strategy.resolved.modelId,
+			tools: agentConfig.tools,
+			prompt,
+			thinkingLevel: strategy.resolved.thinkingLevel ?? agentConfig.defaultThinkingLevel,
+			inheritMessages: false,
+			ipcForward: true,
+			keyOverride: strategy.resolved.keyOverride,
+		});
+
+		return {
+			session_id: sessionId,
+			mode: "sync",
+			output: result.finalText,
+			model_used: strategy.resolved.modelId,
+			agent_used: strategy.agentName,
+			metadata: {
+				started_at: startedAt,
+				completed_at: new Date().toISOString(),
+				token_usage: result.tokenUsage,
+				resolved_via: strategy.resolved.resolvedVia,
+			},
+		};
+	}
+
+	private async executeBackground(
+		params: TaskDelegateParams,
+		strategy: ExecutionStrategy,
+		ctx: ExtensionContext,
+	): Promise<TaskDelegateResult> {
+		const taskId = `task_${randomUUID()}`;
+		const sessionId = params.session_id ?? `ses_${randomUUID()}`;
+		const startedAt = new Date().toISOString();
+
+		const handle: BackgroundTaskHandle = {
+			taskId,
+			sessionId,
+			status: "running",
+			cancelled: false,
+			promise: this.executeSync({ ...params, session_id: sessionId, run_in_background: false }, strategy, ctx)
+				.then((result) => {
+					handle.status = handle.cancelled ? "cancelled" : "completed";
+					return result;
+				})
+				.catch((error) => {
+					handle.status = handle.cancelled ? "cancelled" : "failed";
+					throw error;
+				}),
+		};
+
+		this.backgroundTasks.set(taskId, handle);
+		void handle.promise.catch(() => {
+			// status already updated in chain
+		});
+
+		return {
+			session_id: sessionId,
+			mode: "background",
+			task_id: taskId,
+			model_used: strategy.resolved.modelId,
+			agent_used: strategy.agentName,
+			metadata: {
+				started_at: startedAt,
+				resolved_via: strategy.resolved.resolvedVia,
+			},
+		};
+	}
+
+	private applySkillPrelude(prompt: string, skills: string[] | undefined): string {
+		if (!skills || skills.length === 0) {
+			return prompt;
+		}
+		return [`Requested skills: ${skills.join(", ")}`, "", prompt].join("\n");
+	}
+}

--- a/extensions/multi-agent/src/prompts/DynamicPromptBuilder.ts
+++ b/extensions/multi-agent/src/prompts/DynamicPromptBuilder.ts
@@ -1,0 +1,42 @@
+import type { AgentRegistry } from "../registry/AgentRegistry.js";
+import type { CategoryRouter } from "../routing/CategoryRouter.js";
+
+export class DynamicPromptBuilder {
+	constructor(
+		private readonly registry: AgentRegistry,
+		private readonly categoryRouter: CategoryRouter,
+	) {}
+
+	buildOrchestratorPrompt(basePrompt: string): string {
+		const agents = this.registry
+			.list()
+			.map((name) => {
+				const metadata = this.registry.getMetadata(name);
+				if (!metadata) {
+					return undefined;
+				}
+				return `- ${name} [${metadata.mode}] — ${metadata.description} (when: ${metadata.whenToUse})`;
+			})
+			.filter((value): value is string => !!value);
+
+		const categories = this.categoryRouter
+			.list()
+			.map((category) => `- ${category.name}: ${category.description} -> default ${category.defaultAgent}`);
+
+		return [
+			basePrompt,
+			"",
+			"## Phase workflow",
+			"1) Classify intent",
+			"2) Assess relevant files and risks",
+			"3) Delegate focused work with task()",
+			"4) Validate and summarize results",
+			"",
+			"## Registered agents",
+			...agents,
+			"",
+			"## Categories",
+			...categories,
+		].join("\n");
+	}
+}

--- a/extensions/multi-agent/src/registry/AgentRegistry.ts
+++ b/extensions/multi-agent/src/registry/AgentRegistry.ts
@@ -1,0 +1,85 @@
+import type { AgentConfig, AgentFactory, AgentMode, RegisteredAgent } from "./types.js";
+
+export class AgentRegistry {
+	private readonly registry = new Map<string, RegisteredAgent>();
+	private readonly sourceIndex = new Map<string, Set<string>>();
+
+	register(name: string, factory: AgentFactory, sourceId = "core"): void {
+		this.registry.set(name, {
+			factory,
+			sourceId,
+			registeredAt: new Date(),
+			disabled: false,
+		});
+
+		const names = this.sourceIndex.get(sourceId) ?? new Set<string>();
+		names.add(name);
+		this.sourceIndex.set(sourceId, names);
+	}
+
+	get(name: string): AgentFactory | undefined {
+		const entry = this.registry.get(name);
+		if (!entry || entry.disabled) {
+			return undefined;
+		}
+		return entry.factory;
+	}
+
+	instantiate(name: string, model: string): AgentConfig {
+		const factory = this.get(name);
+		if (!factory) {
+			throw new Error(`Unknown agent: ${name}`);
+		}
+		return factory(model);
+	}
+
+	list(mode?: AgentMode, includeAllMode = true): string[] {
+		const names: string[] = [];
+		for (const [name, entry] of this.registry.entries()) {
+			if (entry.disabled) {
+				continue;
+			}
+			if (!mode) {
+				names.push(name);
+				continue;
+			}
+			if (entry.factory.mode === mode || (includeAllMode && entry.factory.mode === "all")) {
+				names.push(name);
+			}
+		}
+		return names;
+	}
+
+	setDisabled(name: string, disabled: boolean): void {
+		const entry = this.registry.get(name);
+		if (entry) {
+			entry.disabled = disabled;
+		}
+	}
+
+	unregisterBySource(sourceId: string): void {
+		const names = this.sourceIndex.get(sourceId);
+		if (!names) {
+			return;
+		}
+		for (const name of names) {
+			this.registry.delete(name);
+		}
+		this.sourceIndex.delete(sourceId);
+	}
+
+	getMetadata(name: string): { mode: AgentMode; description: string; whenToUse: string } | undefined {
+		const entry = this.registry.get(name);
+		if (!entry || entry.disabled) {
+			return undefined;
+		}
+		const config = entry.factory("");
+		return {
+			mode: entry.factory.mode,
+			description: config.description,
+			whenToUse: config.whenToUse,
+		};
+	}
+}
+
+export const globalAgentRegistry = new AgentRegistry();

--- a/extensions/multi-agent/src/registry/types.ts
+++ b/extensions/multi-agent/src/registry/types.ts
@@ -1,0 +1,26 @@
+import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
+
+export type AgentMode = "primary" | "subagent" | "all";
+
+export interface AgentConfig {
+	name: string;
+	description: string;
+	whenToUse: string;
+	systemPrompt: string;
+	tools: string[];
+	defaultThinkingLevel?: ThinkingLevel;
+	metadata?: Record<string, unknown>;
+}
+
+export interface AgentFactory {
+	(model: string): AgentConfig;
+	mode: AgentMode;
+	supportedCategories?: string[];
+}
+
+export interface RegisteredAgent {
+	factory: AgentFactory;
+	sourceId: string;
+	registeredAt: Date;
+	disabled: boolean;
+}

--- a/extensions/multi-agent/src/routing/CategoryRouter.ts
+++ b/extensions/multi-agent/src/routing/CategoryRouter.ts
@@ -1,0 +1,109 @@
+import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { AgentModelConfig, CategoryAgentMap } from "./types.js";
+
+export interface CategoryDefinition {
+	name: string;
+	description: string;
+	useCases: string[];
+	defaultAgent: string;
+	defaultModel?: string;
+	thinkingLevel?: ThinkingLevel;
+}
+
+export const DEFAULT_CATEGORIES: CategoryDefinition[] = [
+	{
+		name: "visual-engineering",
+		description: "UI and layout oriented implementation work",
+		useCases: ["component styling", "layout fixes", "interactive UI"],
+		defaultAgent: "sisyphus-junior",
+		defaultModel: "google/gemini-2.5-pro",
+		thinkingLevel: "high",
+	},
+	{
+		name: "ultrabrains",
+		description: "Complex reasoning and architecture tasks",
+		useCases: ["algorithm design", "system architecture", "root cause analysis"],
+		defaultAgent: "sisyphus-junior",
+		defaultModel: "openai/o3",
+		thinkingLevel: "xhigh",
+	},
+	{
+		name: "deep",
+		description: "Deep code analysis and refactoring",
+		useCases: ["debugging", "performance tuning", "large refactors"],
+		defaultAgent: "explore",
+		defaultModel: "anthropic/claude-opus-4-6",
+		thinkingLevel: "high",
+	},
+	{
+		name: "quick",
+		description: "Fast low-cost iteration",
+		useCases: ["small fixes", "quick checks", "format updates"],
+		defaultAgent: "sisyphus-junior",
+		defaultModel: "anthropic/claude-haiku-4-5",
+		thinkingLevel: "low",
+	},
+	{
+		name: "research",
+		description: "Investigation and documentation search",
+		useCases: ["API docs", "dependency research", "external references"],
+		defaultAgent: "oracle",
+		defaultModel: "anthropic/claude-sonnet-4-6",
+		thinkingLevel: "medium",
+	},
+	{
+		name: "unspecified-low",
+		description: "Default uncategorized tasks with low cost",
+		useCases: ["general coding"],
+		defaultAgent: "sisyphus-junior",
+		defaultModel: "google/gemini-2.5-flash",
+		thinkingLevel: "low",
+	},
+	{
+		name: "unspecified-high",
+		description: "Default uncategorized tasks with high quality",
+		useCases: ["complex uncategorized work"],
+		defaultAgent: "sisyphus-junior",
+		defaultModel: "anthropic/claude-opus-4-6",
+		thinkingLevel: "high",
+	},
+];
+
+export class CategoryRouter {
+	private readonly categories: Map<string, CategoryDefinition>;
+
+	constructor(categories: CategoryDefinition[] = DEFAULT_CATEGORIES) {
+		this.categories = new Map(categories.map((category) => [category.name, category]));
+	}
+
+	get(name: string): CategoryDefinition | undefined {
+		return this.categories.get(name);
+	}
+
+	getDefaultAgent(name: string): string {
+		return this.categories.get(name)?.defaultAgent ?? "sisyphus-junior";
+	}
+
+	list(): CategoryDefinition[] {
+		return Array.from(this.categories.values());
+	}
+
+	toCategoryModelConfig(): Record<string, AgentModelConfig> {
+		const result: Record<string, AgentModelConfig> = {};
+		for (const category of this.categories.values()) {
+			result[category.name] = {
+				model: category.defaultModel,
+				thinkingLevel: category.thinkingLevel,
+			};
+		}
+		return result;
+	}
+
+	toCategoryAgentMap(): CategoryAgentMap {
+		const result: CategoryAgentMap = {};
+		for (const category of this.categories.values()) {
+			result[category.name] = category.defaultAgent;
+		}
+		return result;
+	}
+}

--- a/extensions/multi-agent/src/routing/FallbackChain.ts
+++ b/extensions/multi-agent/src/routing/FallbackChain.ts
@@ -1,0 +1,13 @@
+import type { ModelChainEntry } from "./types.js";
+
+export function normalizeModelChain(entries: Array<string | ModelChainEntry> | undefined): ModelChainEntry[] {
+	if (!entries || entries.length === 0) {
+		return [];
+	}
+	return entries.map((entry) => {
+		if (typeof entry === "string") {
+			return { model: entry };
+		}
+		return entry;
+	});
+}

--- a/extensions/multi-agent/src/routing/ModelRouter.ts
+++ b/extensions/multi-agent/src/routing/ModelRouter.ts
@@ -1,0 +1,364 @@
+import type { Model } from "@mariozechner/pi-ai";
+import type {
+	AgentModelConfig,
+	ModelChainEntry,
+	ModelRegistryView,
+	MultiAgentConfig,
+	ResolvedModel,
+	RuntimeModelOverride,
+	ThinkingLevel,
+	ProviderKeyOverrides,
+	ModelRouterRuntimeState,
+} from "./types.js";
+
+const DEFAULT_LAST_RESORT_MODEL = "google/gemini-2.5-flash-lite-preview-06-17";
+
+interface ParsedModelRef {
+	provider?: string;
+	modelId: string;
+}
+
+function parseModelRef(modelRef: string): ParsedModelRef {
+	const separatorIndex = modelRef.indexOf("/");
+	if (separatorIndex === -1) {
+		return { modelId: modelRef };
+	}
+	return {
+		provider: modelRef.slice(0, separatorIndex),
+		modelId: modelRef.slice(separatorIndex + 1),
+	};
+}
+
+function modelKey(model: Model<any>): string {
+	return `${model.provider}/${model.id}`;
+}
+
+function modelMatchesReference(model: Model<any>, parsed: ParsedModelRef): boolean {
+	if (parsed.provider && model.provider !== parsed.provider) {
+		return false;
+	}
+	return model.id === parsed.modelId;
+}
+
+function modelSatisfiesConstraints(model: Model<any>, config: AgentModelConfig): boolean {
+	if (config.maxCostPerMToken !== undefined && model.cost.input > config.maxCostPerMToken) {
+		return false;
+	}
+	if (config.minContextWindow !== undefined && model.contextWindow < config.minContextWindow) {
+		return false;
+	}
+	if (config.requiredCapabilities?.includes("image") && !model.input.includes("image")) {
+		return false;
+	}
+	if (config.requireReasoning && !model.reasoning) {
+		return false;
+	}
+	return true;
+}
+
+function modelPreference(left: Model<any>, right: Model<any>): number {
+	if (left.reasoning !== right.reasoning) {
+		return left.reasoning ? -1 : 1;
+	}
+	if (left.contextWindow !== right.contextWindow) {
+		return right.contextWindow - left.contextWindow;
+	}
+	const leftCost = left.cost.input + left.cost.output;
+	const rightCost = right.cost.input + right.cost.output;
+	if (leftCost !== rightCost) {
+		return leftCost - rightCost;
+	}
+	return left.id.localeCompare(right.id);
+}
+
+export class ModelRouter {
+	private readonly agentConfigs: Map<string, AgentModelConfig>;
+	private readonly categoryConfigs: Map<string, AgentModelConfig>;
+	private readonly providerKeys: ProviderKeyOverrides;
+	private readonly modelRegistry: ModelRegistryView;
+	private readonly lastResortModel: string;
+	private readonly runtimeState: ModelRouterRuntimeState;
+
+	constructor(options: {
+		agentConfigs?: Map<string, AgentModelConfig>;
+		categoryConfigs?: Map<string, AgentModelConfig>;
+		providerKeys?: ProviderKeyOverrides;
+		modelRegistry: ModelRegistryView;
+		lastResortModel?: string;
+		runtimeState?: ModelRouterRuntimeState;
+	}) {
+		this.agentConfigs = options.agentConfigs ?? new Map();
+		this.categoryConfigs = options.categoryConfigs ?? new Map();
+		this.providerKeys = options.providerKeys ?? {};
+		this.modelRegistry = options.modelRegistry;
+		this.lastResortModel = options.lastResortModel ?? DEFAULT_LAST_RESORT_MODEL;
+		this.runtimeState = options.runtimeState ?? { overrides: new Map() };
+	}
+
+	static fromConfig(config: MultiAgentConfig, modelRegistry: ModelRegistryView): ModelRouter {
+		return new ModelRouter({
+			agentConfigs: new Map(Object.entries(config.agents ?? {})),
+			categoryConfigs: new Map(Object.entries(config.categories ?? {})),
+			providerKeys: config.providerKeys,
+			modelRegistry,
+			lastResortModel: config.lastResortModel,
+		});
+	}
+
+	setAgentModel(agentName: string, model: string, thinkingLevel?: ThinkingLevel): void {
+		this.runtimeState.overrides.set(agentName, {
+			model,
+			thinkingLevel,
+		});
+	}
+
+	setAgentProvider(agentName: string, provider: string, thinkingLevel?: ThinkingLevel): void {
+		this.runtimeState.overrides.set(agentName, {
+			provider,
+			thinkingLevel,
+		});
+	}
+
+	resetAgentModel(agentName: string): void {
+		this.runtimeState.overrides.delete(agentName);
+	}
+
+	getRuntimeOverride(agentName: string): RuntimeModelOverride | undefined {
+		const override = this.runtimeState.overrides.get(agentName);
+		if (!override) {
+			return undefined;
+		}
+		return { ...override };
+	}
+
+	async resolveForAgent(agentName: string, category?: string): Promise<ResolvedModel> {
+		const runtimeOverride = this.runtimeState.overrides.get(agentName);
+		if (runtimeOverride?.model) {
+			const runtimeResolved = this.resolveModelDirect(
+				runtimeOverride.model,
+				agentName,
+				{ thinkingLevel: runtimeOverride.thinkingLevel },
+				"runtime_model_direct",
+			);
+			if (runtimeResolved) {
+				return runtimeResolved;
+			}
+		}
+		if (runtimeOverride?.provider) {
+			const runtimeResolved = this.resolveProviderAuto(
+				runtimeOverride.provider,
+				agentName,
+				{ thinkingLevel: runtimeOverride.thinkingLevel },
+				"runtime_provider_auto",
+			);
+			if (runtimeResolved) {
+				return runtimeResolved;
+			}
+		}
+
+		const config = this.agentConfigs.get(agentName);
+		if (config?.disabled) {
+			throw new Error(`Agent is disabled: ${agentName}`);
+		}
+
+		if (config?.model) {
+			const resolved = this.resolveModelDirect(config.model, agentName, config, "agent_model_direct");
+			if (resolved) {
+				return resolved;
+			}
+		}
+
+		if (config?.provider) {
+			const resolved = this.resolveProviderAuto(config.provider, agentName, config, "agent_provider_auto");
+			if (resolved) {
+				return resolved;
+			}
+		}
+
+		if (config?.modelChain?.length) {
+			const resolved = await this.resolveModelChain(config.modelChain, agentName, config, "agent_model_chain");
+			if (resolved) {
+				return resolved;
+			}
+		}
+
+		if (category || config?.useCategory) {
+			const categoryName = category ?? "unspecified-low";
+			const categoryResolved = await this.resolveForCategory(categoryName, agentName);
+			if (categoryResolved) {
+				return categoryResolved;
+			}
+		}
+
+		return this.resolveLastResort(agentName);
+	}
+
+	async resolveForCategory(categoryName: string, agentName: string): Promise<ResolvedModel | null> {
+		const config = this.categoryConfigs.get(categoryName);
+		if (!config || config.disabled) {
+			return null;
+		}
+
+		if (config.model) {
+			const resolved = this.resolveModelDirect(config.model, agentName, config, "category_override");
+			if (resolved) {
+				return resolved;
+			}
+		}
+
+		if (config.provider) {
+			const resolved = this.resolveProviderAuto(config.provider, agentName, config, "category_override");
+			if (resolved) {
+				return resolved;
+			}
+		}
+
+		if (config.modelChain?.length) {
+			const resolved = await this.resolveModelChain(config.modelChain, agentName, config, "category_chain");
+			if (resolved) {
+				return resolved;
+			}
+		}
+
+		return null;
+	}
+
+	private resolveLastResort(agentName: string): ResolvedModel {
+		const direct = this.resolveModelDirect(this.lastResortModel, agentName, {}, "last_resort");
+		if (direct) {
+			return direct;
+		}
+
+		const fallback = this.modelRegistry.getAvailable()[0] ?? this.modelRegistry.getAll()[0];
+		if (!fallback) {
+			throw new Error("No models available for multi-agent routing");
+		}
+		return {
+			modelId: modelKey(fallback),
+			modelInfo: fallback,
+			agentName,
+			resolvedVia: "last_resort",
+			keyOverride: this.getKeyOverride(agentName, fallback.provider),
+		};
+	}
+
+	private resolveModelDirect(
+		modelRef: string,
+		agentName: string,
+		config: AgentModelConfig,
+		resolvedVia: ResolvedModel["resolvedVia"],
+	): ResolvedModel | null {
+		const parsed = parseModelRef(modelRef);
+		const candidates = this.modelRegistry
+			.getAll()
+			.filter((candidate) => modelMatchesReference(candidate, parsed))
+			.filter((candidate) => modelSatisfiesConstraints(candidate, config))
+			.sort(modelPreference);
+
+		const chosen = candidates[0];
+		if (!chosen) {
+			return null;
+		}
+		return {
+			modelId: modelKey(chosen),
+			modelInfo: chosen,
+			thinkingLevel: config.thinkingLevel,
+			agentName,
+			resolvedVia,
+			keyOverride: this.getKeyOverride(agentName, chosen.provider),
+		};
+	}
+
+	private resolveProviderAuto(
+		provider: string,
+		agentName: string,
+		config: AgentModelConfig,
+		resolvedVia: ResolvedModel["resolvedVia"],
+	): ResolvedModel | null {
+		const availableByProvider = this.modelRegistry
+			.getAvailable()
+			.filter((candidate) => candidate.provider === provider)
+			.filter((candidate) => modelSatisfiesConstraints(candidate, config))
+			.sort(modelPreference);
+
+		const allByProvider = this.modelRegistry
+			.getAll()
+			.filter((candidate) => candidate.provider === provider)
+			.filter((candidate) => modelSatisfiesConstraints(candidate, config))
+			.sort(modelPreference);
+
+		const chosen = availableByProvider[0] ?? allByProvider[0];
+		if (!chosen) {
+			return null;
+		}
+
+		return {
+			modelId: modelKey(chosen),
+			modelInfo: chosen,
+			thinkingLevel: config.thinkingLevel,
+			agentName,
+			resolvedVia,
+			keyOverride: this.getKeyOverride(agentName, provider),
+		};
+	}
+
+	private async resolveModelChain(
+		chain: ModelChainEntry[],
+		agentName: string,
+		config: AgentModelConfig,
+		resolvedVia: ResolvedModel["resolvedVia"],
+	): Promise<ResolvedModel | null> {
+		for (const entry of chain) {
+			if (!(await this.isChainEntryAvailable(entry))) {
+				continue;
+			}
+
+			const resolved = this.resolveModelDirect(entry.model, agentName, config, resolvedVia);
+			if (!resolved) {
+				continue;
+			}
+			return {
+				...resolved,
+				thinkingLevel: entry.thinkingLevel ?? config.thinkingLevel,
+			};
+		}
+		return null;
+	}
+
+	private async isChainEntryAvailable(entry: ModelChainEntry): Promise<boolean> {
+		const condition = entry.condition;
+		if (!condition || condition.type === "always") {
+			return true;
+		}
+
+		if (condition.type === "provider_available") {
+			return this.modelRegistry.getAvailable().some((model) => model.provider === condition.provider);
+		}
+		if (condition.type === "model_available") {
+			const parsed = parseModelRef(condition.modelId);
+			return this.modelRegistry.getAvailable().some((model) => modelMatchesReference(model, parsed));
+		}
+		if (condition.type === "api_key_set") {
+			return typeof process.env[condition.envVar] === "string" && process.env[condition.envVar]!.length > 0;
+		}
+
+		return false;
+	}
+
+	private getKeyOverride(agentName: string, provider: string): ResolvedModel["keyOverride"] | undefined {
+		const byAgent = this.providerKeys[agentName];
+		if (!byAgent) {
+			return undefined;
+		}
+		const override = byAgent[provider];
+		if (!override) {
+			return undefined;
+		}
+		return {
+			provider,
+			envVar: override.envVar,
+			apiKey: override.apiKey,
+			baseUrl: override.baseUrl,
+		};
+	}
+}

--- a/extensions/multi-agent/src/routing/types.ts
+++ b/extensions/multi-agent/src/routing/types.ts
@@ -1,0 +1,108 @@
+import type { Model } from "@mariozechner/pi-ai";
+import type { ThinkingLevel as AgentThinkingLevel } from "@mariozechner/pi-agent-core";
+
+export type ThinkingLevel = AgentThinkingLevel;
+
+export type ModelCapability = "image" | "reasoning" | "tool_calling";
+
+export interface ModelConditionProviderAvailable {
+	type: "provider_available";
+	provider: string;
+}
+
+export interface ModelConditionModelAvailable {
+	type: "model_available";
+	modelId: string;
+}
+
+export interface ModelConditionApiKeySet {
+	type: "api_key_set";
+	envVar: string;
+}
+
+export interface ModelConditionAlways {
+	type: "always";
+}
+
+export type ModelCondition =
+	| ModelConditionProviderAvailable
+	| ModelConditionModelAvailable
+	| ModelConditionApiKeySet
+	| ModelConditionAlways;
+
+export interface ModelChainEntry {
+	model: string;
+	thinkingLevel?: ThinkingLevel;
+	condition?: ModelCondition;
+}
+
+export interface AgentModelConfig {
+	model?: string;
+	provider?: string;
+	modelChain?: ModelChainEntry[];
+	useCategory?: boolean;
+	thinkingLevel?: ThinkingLevel;
+	disabled?: boolean;
+	maxCostPerMToken?: number;
+	minContextWindow?: number;
+	requiredCapabilities?: ModelCapability[];
+	requireReasoning?: boolean;
+}
+
+export interface ProviderKeyOverride {
+	envVar?: string;
+	apiKey?: string;
+	baseUrl?: string;
+}
+
+export interface ProviderKeyOverrides {
+	[agentName: string]: {
+		[provider: string]: ProviderKeyOverride;
+	};
+}
+
+export interface MultiAgentConfig {
+	enabled?: boolean;
+	agents?: Record<string, AgentModelConfig>;
+	categories?: Record<string, AgentModelConfig>;
+	providerKeys?: ProviderKeyOverrides;
+	lastResortModel?: string;
+}
+
+export type ResolveMethod =
+	| "runtime_model_direct"
+	| "runtime_provider_auto"
+	| "agent_model_direct"
+	| "agent_provider_auto"
+	| "agent_model_chain"
+	| "category_override"
+	| "category_chain"
+	| "last_resort";
+
+export interface ResolvedModel {
+	modelId: string;
+	modelInfo: Model<any>;
+	thinkingLevel?: ThinkingLevel;
+	agentName: string;
+	resolvedVia: ResolveMethod;
+	keyOverride?: { provider: string; envVar?: string; apiKey?: string; baseUrl?: string };
+}
+
+export interface RuntimeModelOverride {
+	model?: string;
+	provider?: string;
+	thinkingLevel?: ThinkingLevel;
+}
+
+export interface ModelRouterRuntimeState {
+	overrides: Map<string, RuntimeModelOverride>;
+}
+
+export interface ModelRegistryView {
+	getAll(): Model<any>[];
+	getAvailable(): Model<any>[];
+}
+
+export interface CategoryAgentMap {
+	[category: string]: string;
+}

--- a/extensions/multi-agent/src/tools/background-task-tool.ts
+++ b/extensions/multi-agent/src/tools/background-task-tool.ts
@@ -1,0 +1,60 @@
+import { Type } from "@sinclair/typebox";
+import type { ExtensionContext, ToolDefinition } from "@mariozechner/pi-coding-agent";
+import type { TaskDelegator } from "../orchestration/TaskDelegator.js";
+
+const BackgroundOutputParams = Type.Object({
+	task_id: Type.String({ minLength: 1 }),
+});
+
+const BackgroundCancelParams = Type.Object({
+	task_id: Type.String({ minLength: 1 }),
+});
+
+export function createBackgroundOutputTool(
+	getDelegator: (ctx: ExtensionContext) => TaskDelegator,
+): ToolDefinition<typeof BackgroundOutputParams, { status: string }> {
+	return {
+		name: "background_output",
+		label: "Background Output",
+		description: "Read status of a background task started by task(run_in_background=true)",
+		parameters: BackgroundOutputParams,
+		execute: async (_toolCallId, params, _signal, _onUpdate, ctx) => {
+			const status = getDelegator(ctx).getBackgroundTask(params.task_id);
+			if (!status) {
+				return {
+					content: [{ type: "text", text: `No background task found for ${params.task_id}.` }],
+					details: { status: "missing" },
+				};
+			}
+			return {
+				content: [{ type: "text", text: `Background task ${params.task_id}: ${status.status}` }],
+				details: { status: status.status },
+			};
+		},
+	};
+}
+
+export function createBackgroundCancelTool(
+	getDelegator: (ctx: ExtensionContext) => TaskDelegator,
+): ToolDefinition<typeof BackgroundCancelParams, { cancelled: boolean }> {
+	return {
+		name: "background_cancel",
+		label: "Background Cancel",
+		description: "Request cancellation for a running background task",
+		parameters: BackgroundCancelParams,
+		execute: async (_toolCallId, params, _signal, _onUpdate, ctx) => {
+			const cancelled = getDelegator(ctx).cancelBackgroundTask(params.task_id);
+			return {
+				content: [
+					{
+						type: "text",
+						text: cancelled
+							? `Cancellation requested for ${params.task_id}.`
+							: `Task ${params.task_id} is not running or does not exist.`,
+					},
+				],
+				details: { cancelled },
+			};
+		},
+	};
+}

--- a/extensions/multi-agent/src/tools/shared-state-tool.ts
+++ b/extensions/multi-agent/src/tools/shared-state-tool.ts
@@ -1,0 +1,51 @@
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
+import { SharedStateManager } from "@mariozechner/pi-ipc";
+
+const SharedStateParams = Type.Object({
+	namespace: Type.String({ minLength: 1 }),
+	key: Type.String({ minLength: 1 }),
+	operation: Type.Union([Type.Literal("read"), Type.Literal("write"), Type.Literal("delete")]),
+	value: Type.Optional(Type.Unknown()),
+});
+
+function createManager(cwd: string): SharedStateManager {
+	const baseDir = join(cwd, ".pi", "multiagent", "state");
+	if (!existsSync(baseDir)) {
+		mkdirSync(baseDir, { recursive: true });
+	}
+	return new SharedStateManager({ baseDir });
+}
+
+export function createSharedStateTool(): ToolDefinition<typeof SharedStateParams, { namespace: string; key: string }> {
+	return {
+		name: "shared_state",
+		label: "Shared State",
+		description: "Read/write/delete namespaced shared state records used by multi-agent flows",
+		parameters: SharedStateParams,
+		execute: async (_toolCallId, params, _signal, _onUpdate, ctx) => {
+			const manager = createManager(ctx.cwd);
+			if (params.operation === "read") {
+				const record = manager.read(params.namespace, params.key);
+				return {
+					content: [{ type: "text", text: JSON.stringify(record ?? null, null, 2) }],
+					details: { namespace: params.namespace, key: params.key },
+				};
+			}
+			if (params.operation === "write") {
+				const record = manager.write(params.namespace, params.key, params.value);
+				return {
+					content: [{ type: "text", text: JSON.stringify(record, null, 2) }],
+					details: { namespace: params.namespace, key: params.key },
+				};
+			}
+			const removed = manager.delete(params.namespace, params.key);
+			return {
+				content: [{ type: "text", text: removed ? "deleted" : "not_found" }],
+				details: { namespace: params.namespace, key: params.key },
+			};
+		},
+	};
+}

--- a/extensions/multi-agent/src/tools/task-tool.ts
+++ b/extensions/multi-agent/src/tools/task-tool.ts
@@ -1,0 +1,63 @@
+import { Type, type Static } from "@sinclair/typebox";
+import type { ExtensionContext, ToolDefinition } from "@mariozechner/pi-coding-agent";
+import type { TaskDelegator, TaskDelegateResult } from "../orchestration/TaskDelegator.js";
+
+export const TaskToolParameters = Type.Object({
+	prompt: Type.String({ minLength: 1, description: "Prompt sent to delegated sub-agent" }),
+	category: Type.Optional(Type.String({ description: "Optional category for automatic routing" })),
+	agent: Type.Optional(Type.String({ description: "Explicit sub-agent name" })),
+	session_id: Type.Optional(Type.String({ description: "Existing sub-agent session id" })),
+	run_in_background: Type.Optional(Type.Boolean({ description: "Run delegation asynchronously" })),
+	load_skills: Type.Optional(Type.Array(Type.String(), { description: "Skill identifiers to load" })),
+	max_prompt_tokens: Type.Optional(Type.Number({ minimum: 1, description: "Optional prompt token budget hint" })),
+});
+
+export type TaskToolInput = Static<typeof TaskToolParameters>;
+
+interface TaskToolDetails {
+	result: TaskDelegateResult;
+}
+
+function formatOutput(result: TaskDelegateResult): string {
+	if (result.mode === "background") {
+		return [
+			`Delegated in background as ${result.task_id}.`,
+			`session_id: ${result.session_id}`,
+			`agent: ${result.agent_used}`,
+			`model: ${result.model_used}`,
+		].join("\n");
+	}
+
+	return [
+		`Delegation completed by ${result.agent_used}.`,
+		`session_id: ${result.session_id}`,
+		`model: ${result.model_used}`,
+		result.output ? "" : undefined,
+		result.output,
+	]
+		.filter((line): line is string => typeof line === "string")
+		.join("\n");
+}
+
+export function createTaskTool(
+	getDelegator: (ctx: ExtensionContext) => TaskDelegator,
+): ToolDefinition<typeof TaskToolParameters, TaskToolDetails> {
+	return {
+		name: "task",
+		label: "Task",
+		description: "Delegate a focused task to a specialized sub-agent",
+		promptSnippet: "task(prompt, category?, agent?) delegates work to a sub-agent and returns its result.",
+		promptGuidelines: [
+			"Use task() for focused sub-work when decomposition improves reliability.",
+			"Prefer category routing unless a specific agent is required.",
+		],
+		parameters: TaskToolParameters,
+		execute: async (_toolCallId, params, _signal, _onUpdate, ctx: ExtensionContext) => {
+			const result = await getDelegator(ctx).execute(params, ctx);
+			return {
+				content: [{ type: "text", text: formatOutput(result) }],
+				details: { result },
+			};
+		},
+	};
+}

--- a/extensions/multi-agent/test/model-router.test.ts
+++ b/extensions/multi-agent/test/model-router.test.ts
@@ -1,0 +1,164 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { describe, expect, test } from "vitest";
+import { ModelRouter } from "../src/routing/ModelRouter.js";
+import type { ModelRegistryView, MultiAgentConfig } from "../src/routing/types.js";
+
+function model(input: {
+	provider: string;
+	id: string;
+	reasoning: boolean;
+	contextWindow: number;
+	input: ("text" | "image")[];
+	costInput: number;
+	costOutput: number;
+}): Model<Api> {
+	return {
+		id: input.id,
+		name: `${input.provider}/${input.id}`,
+		api: "openai-completions",
+		provider: input.provider,
+		baseUrl: `https://${input.provider}.example.com`,
+		reasoning: input.reasoning,
+		input: input.input,
+		cost: {
+			input: input.costInput,
+			output: input.costOutput,
+			cacheRead: 0,
+			cacheWrite: 0,
+		},
+		contextWindow: input.contextWindow,
+		maxTokens: 8192,
+	};
+}
+
+const ALL_MODELS: Model<Api>[] = [
+	model({
+		provider: "anthropic",
+		id: "claude-opus-4-6",
+		reasoning: true,
+		contextWindow: 200_000,
+		input: ["text", "image"],
+		costInput: 15,
+		costOutput: 75,
+	}),
+	model({
+		provider: "anthropic",
+		id: "claude-haiku-4-5",
+		reasoning: false,
+		contextWindow: 200_000,
+		input: ["text", "image"],
+		costInput: 1,
+		costOutput: 5,
+	}),
+	model({
+		provider: "openai",
+		id: "o3",
+		reasoning: true,
+		contextWindow: 200_000,
+		input: ["text", "image"],
+		costInput: 10,
+		costOutput: 40,
+	}),
+	model({
+		provider: "google",
+		id: "gemini-2.5-pro",
+		reasoning: true,
+		contextWindow: 1_000_000,
+		input: ["text", "image"],
+		costInput: 1.25,
+		costOutput: 10,
+	}),
+];
+
+function registry(available: string[]): ModelRegistryView {
+	const availableSet = new Set(available);
+	return {
+		getAll: () => ALL_MODELS,
+		getAvailable: () => ALL_MODELS.filter((candidate) => availableSet.has(`${candidate.provider}/${candidate.id}`)),
+	};
+}
+
+describe("ModelRouter", () => {
+	test("resolves direct model and provider key override", async () => {
+		const config: MultiAgentConfig = {
+			agents: {
+				oracle: {
+					model: "anthropic/claude-opus-4-6",
+					thinkingLevel: "high",
+				},
+			},
+			providerKeys: {
+				oracle: {
+					anthropic: { envVar: "ANTHROPIC_API_KEY_PREMIUM" },
+				},
+			},
+		};
+		const router = ModelRouter.fromConfig(config, registry(["anthropic/claude-opus-4-6"]));
+
+		const resolved = await router.resolveForAgent("oracle");
+		expect(resolved.modelId).toBe("anthropic/claude-opus-4-6");
+		expect(resolved.resolvedVia).toBe("agent_model_direct");
+		expect(resolved.keyOverride?.envVar).toBe("ANTHROPIC_API_KEY_PREMIUM");
+	});
+
+	test("falls through model chain when provider unavailable", async () => {
+		const config: MultiAgentConfig = {
+			agents: {
+				hephaestus: {
+					modelChain: [
+						{
+							model: "openai/o3",
+							condition: { type: "provider_available", provider: "openai" },
+						},
+						{
+							model: "anthropic/claude-opus-4-6",
+							condition: { type: "provider_available", provider: "anthropic" },
+						},
+					],
+				},
+			},
+		};
+		const router = ModelRouter.fromConfig(config, registry(["anthropic/claude-opus-4-6"]));
+
+		const resolved = await router.resolveForAgent("hephaestus");
+		expect(resolved.modelId).toBe("anthropic/claude-opus-4-6");
+		expect(resolved.resolvedVia).toBe("agent_model_chain");
+	});
+
+	test("supports runtime overrides", async () => {
+		const config: MultiAgentConfig = {
+			agents: {
+				worker: { provider: "anthropic" },
+			},
+		};
+		const router = ModelRouter.fromConfig(config, registry(["anthropic/claude-opus-4-6", "google/gemini-2.5-pro"]));
+		router.setAgentModel("worker", "google/gemini-2.5-pro", "medium");
+
+		const resolved = await router.resolveForAgent("worker");
+		expect(resolved.modelId).toBe("google/gemini-2.5-pro");
+		expect(resolved.resolvedVia).toBe("runtime_model_direct");
+		expect(resolved.thinkingLevel).toBe("medium");
+
+		router.resetAgentModel("worker");
+		const reset = await router.resolveForAgent("worker");
+		expect(reset.resolvedVia).toBe("agent_provider_auto");
+	});
+
+	test("resolves category fallback and last resort", async () => {
+		const config: MultiAgentConfig = {
+			categories: {
+				quick: { model: "anthropic/claude-haiku-4-5" },
+			},
+			lastResortModel: "google/gemini-2.5-pro",
+		};
+		const router = ModelRouter.fromConfig(config, registry(["google/gemini-2.5-pro"]));
+
+		const categoryResolved = await router.resolveForCategory("quick", "sisyphus-junior");
+		expect(categoryResolved?.modelId).toBe("anthropic/claude-haiku-4-5");
+		expect(categoryResolved?.resolvedVia).toBe("category_override");
+
+		const fallback = await router.resolveForAgent("missing-agent");
+		expect(fallback.modelId).toBe("google/gemini-2.5-pro");
+		expect(fallback.resolvedVia).toBe("last_resort");
+	});
+});

--- a/extensions/multi-agent/test/task-delegator.test.ts
+++ b/extensions/multi-agent/test/task-delegator.test.ts
@@ -1,0 +1,151 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { describe, expect, test } from "vitest";
+import { registerBuiltInAgents } from "../src/agents/index.js";
+import { TaskDelegator } from "../src/orchestration/TaskDelegator.js";
+import { DynamicPromptBuilder } from "../src/prompts/DynamicPromptBuilder.js";
+import { AgentRegistry } from "../src/registry/AgentRegistry.js";
+import { CategoryRouter } from "../src/routing/CategoryRouter.js";
+import type { MultiAgentConfig } from "../src/routing/types.js";
+
+function createContext(): ExtensionContext {
+	return {
+		ui: {
+			select: async () => undefined,
+			confirm: async () => false,
+			input: async () => undefined,
+			notify: () => {},
+			onTerminalInput: () => () => {},
+			setStatus: () => {},
+			setWorkingMessage: () => {},
+			setWidget: () => {},
+			setFooter: () => {},
+			setHeader: () => {},
+			setTitle: () => {},
+			custom: async () => undefined as never,
+			pasteToEditor: () => {},
+			setEditorText: () => {},
+			getEditorText: () => "",
+			editor: async () => undefined,
+			setEditorComponent: () => {},
+			theme: {} as ExtensionContext["ui"]["theme"],
+			getAllThemes: () => [],
+			getTheme: () => undefined,
+			setTheme: () => ({ success: false }),
+			getToolsExpanded: () => false,
+			setToolsExpanded: () => {},
+		},
+		hasUI: false,
+		cwd: process.cwd(),
+		sessionManager: {
+			getCwd: () => process.cwd(),
+			getSessionDir: () => "",
+			getSessionId: () => "ses_root",
+			getSessionFile: () => undefined,
+			getLeafId: () => null,
+			getLeafEntry: () => undefined,
+			getEntry: () => undefined,
+			getLabel: () => undefined,
+			getBranch: () => [],
+			getHeader: () => null,
+			getEntries: () => [],
+			getTree: () => [],
+			getSessionName: () => undefined,
+		},
+		modelRegistry: {
+			getAll: () => [
+				{
+					id: "claude-opus-4-6",
+					name: "claude",
+					api: "anthropic-messages",
+					provider: "anthropic",
+					baseUrl: "https://api.anthropic.com",
+					reasoning: true,
+					input: ["text", "image"],
+					cost: { input: 15, output: 75, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 200_000,
+					maxTokens: 8192,
+				},
+			],
+			getAvailable: () => [
+				{
+					id: "claude-opus-4-6",
+					name: "claude",
+					api: "anthropic-messages",
+					provider: "anthropic",
+					baseUrl: "https://api.anthropic.com",
+					reasoning: true,
+					input: ["text", "image"],
+					cost: { input: 15, output: 75, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 200_000,
+					maxTokens: 8192,
+				},
+			],
+		} as ExtensionContext["modelRegistry"],
+		model: undefined,
+		isIdle: () => true,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		compact: () => {},
+		getSystemPrompt: () => "",
+		runSubAgent: async (options) => ({
+			sessionId: options.sessionId ?? "ses_sub",
+			finalText: `subagent:${options.agentName}:${options.prompt}`,
+			tokenUsage: { input: 12, output: 34 },
+		}),
+	};
+}
+
+describe("TaskDelegator", () => {
+	test("executes synchronous task delegation via runSubAgent hook", async () => {
+		const ctx = createContext();
+		const registry = new AgentRegistry();
+		const categoryRouter = new CategoryRouter();
+		registerBuiltInAgents(registry, new DynamicPromptBuilder(registry, categoryRouter));
+		const config: MultiAgentConfig = {
+			agents: {
+				oracle: {
+					model: "anthropic/claude-opus-4-6",
+				},
+			},
+		};
+		const delegator = new TaskDelegator(registry, categoryRouter, config, ctx);
+
+		const result = await delegator.execute(
+			{
+				prompt: "Audit dependency graph",
+				agent: "oracle",
+				session_id: "ses_oracle",
+			},
+			ctx,
+		);
+
+		expect(result.mode).toBe("sync");
+		expect(result.session_id).toBe("ses_oracle");
+		expect(result.agent_used).toBe("oracle");
+		expect(result.model_used).toBe("anthropic/claude-opus-4-6");
+		expect(result.output).toContain("subagent:oracle");
+		expect(result.metadata.token_usage).toEqual({ input: 12, output: 34 });
+	});
+
+	test("supports background delegation handles", async () => {
+		const ctx = createContext();
+		const registry = new AgentRegistry();
+		const categoryRouter = new CategoryRouter();
+		registerBuiltInAgents(registry, new DynamicPromptBuilder(registry, categoryRouter));
+		const delegator = new TaskDelegator(registry, categoryRouter, {}, ctx);
+
+		const result = await delegator.execute(
+			{
+				prompt: "Quick check",
+				run_in_background: true,
+			},
+			ctx,
+		);
+
+		expect(result.mode).toBe("background");
+		expect(result.task_id).toBeTruthy();
+		expect(["running", "completed"]).toContain(delegator.getBackgroundTask(result.task_id as string)?.status);
+	});
+});

--- a/extensions/multi-agent/tsconfig.build.json
+++ b/extensions/multi-agent/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "dist", "**/*.d.ts", "src/**/*.d.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.3",
 			"workspaces": [
 				"packages/*",
+				"extensions/*",
 				"packages/web-ui/example",
 				"packages/coding-agent/examples/extensions/with-deps",
 				"packages/coding-agent/examples/extensions/custom-provider-anthropic",
@@ -18,8 +19,7 @@
 			"dependencies": {
 				"@mariozechner/jiti": "^2.6.5",
 				"@mariozechner/pi-coding-agent": "^0.30.2",
-				"get-east-asian-width": "^1.4.0",
-				"koffi": "^2.15.1"
+				"get-east-asian-width": "^1.4.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.3.5",
@@ -33,6 +33,38 @@
 			"engines": {
 				"node": ">=20.0.0"
 			}
+		},
+		"extensions/multi-agent": {
+			"name": "@pi/multi-agent",
+			"version": "0.55.4",
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.55.4",
+				"@mariozechner/pi-coding-agent": "^0.55.4",
+				"@mariozechner/pi-ipc": "^0.55.4",
+				"@sinclair/typebox": "^0.34.41"
+			},
+			"devDependencies": {
+				"@types/node": "^24.3.0",
+				"typescript": "^5.7.3",
+				"vitest": "^3.2.4"
+			}
+		},
+		"extensions/multi-agent/node_modules/@types/node": {
+			"version": "24.11.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.11.0.tgz",
+			"integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.16.0"
+			}
+		},
+		"extensions/multi-agent/node_modules/undici-types": {
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@anthropic-ai/sandbox-runtime": {
 			"version": "0.0.16",
@@ -1784,6 +1816,10 @@
 			"resolved": "packages/coding-agent",
 			"link": true
 		},
+		"node_modules/@mariozechner/pi-ipc": {
+			"resolved": "packages/ipc",
+			"link": true
+		},
 		"node_modules/@mariozechner/pi-mom": {
 			"resolved": "packages/mom",
 			"link": true
@@ -2423,6 +2459,10 @@
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
+		},
+		"node_modules/@pi/multi-agent": {
+			"resolved": "extensions/multi-agent",
+			"link": true
 		},
 		"node_modules/@pondwader/socks5-server": {
 			"version": "1.0.10",
@@ -6092,6 +6132,7 @@
 			"integrity": "sha512-mnc0C0crx/xMSljb5s9QbnLrlFHprioFO1hkXyuSuO/QtbpLDa0l/uM21944UfQunMKmp3/r789DTDxVyyH6aA==",
 			"hasInstallScript": true,
 			"license": "MIT",
+			"optional": true,
 			"funding": {
 				"url": "https://liberapay.com/Koromix"
 			}
@@ -8539,6 +8580,7 @@
 				"@mariozechner/jiti": "^2.6.2",
 				"@mariozechner/pi-agent-core": "^0.55.4",
 				"@mariozechner/pi-ai": "^0.55.4",
+				"@mariozechner/pi-ipc": "^0.55.4",
 				"@mariozechner/pi-tui": "^0.55.4",
 				"@silvia-odwyer/photon-node": "^0.3.4",
 				"chalk": "^5.5.0",
@@ -8552,6 +8594,7 @@
 				"marked": "^15.0.12",
 				"minimatch": "^10.2.3",
 				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
 				"yaml": "^2.8.2"
 			},
 			"bin": {
@@ -8618,7 +8661,64 @@
 				"undici-types": "~7.16.0"
 			}
 		},
+		"packages/coding-agent/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"packages/coding-agent/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
 		"packages/coding-agent/node_modules/undici-types": {
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"packages/ipc": {
+			"name": "@mariozechner/pi-ipc",
+			"version": "0.55.4",
+			"license": "MIT",
+			"devDependencies": {
+				"@types/node": "^24.3.0",
+				"typescript": "^5.7.3",
+				"vitest": "^3.2.4"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"packages/ipc/node_modules/@types/node": {
+			"version": "24.11.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.11.0.tgz",
+			"integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.16.0"
+			}
+		},
+		"packages/ipc/node_modules/undici-types": {
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
@@ -8694,7 +8794,6 @@
 				"@types/mime-types": "^2.1.4",
 				"chalk": "^5.5.0",
 				"get-east-asian-width": "^1.3.0",
-				"koffi": "^2.9.0",
 				"marked": "^15.0.12",
 				"mime-types": "^3.0.1"
 			},
@@ -8704,6 +8803,9 @@
 			},
 			"engines": {
 				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
 			}
 		},
 		"packages/tui/node_modules/mime-db": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"type": "module",
 	"workspaces": [
 		"packages/*",
+		"extensions/*",
 		"packages/web-ui/example",
 		"packages/coding-agent/examples/extensions/with-deps",
 		"packages/coding-agent/examples/extensions/custom-provider-anthropic",
@@ -12,7 +13,7 @@
 	],
 	"scripts": {
 		"clean": "npm run clean --workspaces",
-		"build": "cd packages/tui && npm run build && cd ../ai && npm run build && cd ../agent && npm run build && cd ../coding-agent && npm run build && cd ../mom && npm run build && cd ../web-ui && npm run build && cd ../pods && npm run build",
+		"build": "cd packages/tui && npm run build && cd ../ai && npm run build && cd ../agent && npm run build && cd ../ipc && npm run build && cd ../coding-agent && npm run build && cd ../../extensions/multi-agent && npm run build && cd ../../packages/mom && npm run build && cd ../web-ui && npm run build && cd ../pods && npm run build",
 		"dev": "concurrently --names \"ai,agent,coding-agent,mom,web-ui,tui\" --prefix-colors \"cyan,yellow,red,white,green,magenta\" \"cd packages/ai && npm run dev\" \"cd packages/agent && npm run dev\" \"cd packages/coding-agent && npm run dev\" \"cd packages/mom && npm run dev\" \"cd packages/web-ui && npm run dev\" \"cd packages/tui && npm run dev\"",
 		"dev:tsc": "concurrently --names \"ai,web-ui\" --prefix-colors \"cyan,green\" \"cd packages/ai && npm run dev:tsc\" \"cd packages/web-ui && npm run dev:tsc\"",
 		"check": "biome check --write --error-on-warnings . && tsgo --noEmit && cd packages/web-ui && npm run check",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -42,6 +42,7 @@
 		"@mariozechner/jiti": "^2.6.2",
 		"@mariozechner/pi-agent-core": "^0.55.4",
 		"@mariozechner/pi-ai": "^0.55.4",
+		"@mariozechner/pi-ipc": "^0.55.4",
 		"@mariozechner/pi-tui": "^0.55.4",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"chalk": "^5.5.0",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -13,6 +13,7 @@
  * Modes use this class and add their own I/O layer on top.
  */
 
+import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import type {
@@ -23,9 +24,18 @@ import type {
 	AgentTool,
 	ThinkingLevel,
 } from "@mariozechner/pi-agent-core";
+import { Agent as CoreAgent } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, ImageContent, Message, Model, TextContent } from "@mariozechner/pi-ai";
 import { isContextOverflow, modelsAreEqual, resetApiProviders, supportsXhigh } from "@mariozechner/pi-ai";
-import { getDocsPath } from "../config.js";
+import type { IpcMessage, IpcResponse, TaskProgressMessage } from "@mariozechner/pi-ipc";
+import {
+	AgentDiscovery,
+	AgentIpcClient,
+	AgentIpcServer,
+	createIpcMessage,
+	createIpcResponse,
+} from "@mariozechner/pi-ipc";
+import { getAgentDir, getDocsPath } from "../config.js";
 import { theme } from "../modes/interactive/theme/theme.js";
 import { stripFrontmatter } from "../utils/frontmatter.js";
 import { sleep } from "../utils/sleep.js";
@@ -44,6 +54,7 @@ import { DEFAULT_THINKING_LEVEL } from "./defaults.js";
 import { exportSessionToHtml, type ToolHtmlRenderer } from "./export-html/index.js";
 import { createToolHtmlRenderer } from "./export-html/tool-renderer.js";
 import {
+	type AgentRegistryAdapter,
 	type ContextUsage,
 	type ExtensionCommandContextActions,
 	type ExtensionErrorListener,
@@ -58,6 +69,8 @@ import {
 	type SessionBeforeSwitchResult,
 	type SessionBeforeTreeResult,
 	type ShutdownHandler,
+	type SubAgentRunOptions,
+	type SubAgentRunResult,
 	type ToolDefinition,
 	type ToolExecutionEndEvent,
 	type ToolExecutionStartEvent,
@@ -148,6 +161,18 @@ export interface AgentSessionConfig {
 	baseToolsOverride?: Record<string, AgentTool>;
 	/** Mutable ref used by Agent to access the current ExtensionRunner */
 	extensionRunnerRef?: { current?: ExtensionRunner };
+	/** Enable per-session IPC socket server */
+	enableIpc?: boolean;
+	/** Optional socket directory override (defaults to ~/.pi/agent/sockets) */
+	ipcSocketDir?: string;
+	/** Optional callback fired after IPC server start */
+	onIpcServerStart?: (server: AgentIpcServer) => void;
+	/** Optional callback fired before fallback IPC routing */
+	onIpcMessage?: (message: IpcMessage) => Promise<IpcResponse>;
+	/** Optional callback fired after IPC server shutdown */
+	onIpcServerStop?: () => void;
+	/** Optional externally-provided agent registry surfaced to extensions */
+	agentRegistry?: AgentRegistryAdapter;
 }
 
 export interface ExtensionBindings {
@@ -265,6 +290,16 @@ export class AgentSession {
 
 	// Model registry for API key resolution
 	private _modelRegistry: ModelRegistry;
+	private _agentRegistry?: AgentRegistryAdapter;
+
+	// IPC integration
+	private _enableIpc = false;
+	private _ipcSocketDir = join(getAgentDir(), "sockets");
+	private _ipcServer?: AgentIpcServer;
+	private _agentDiscovery?: AgentDiscovery;
+	private _onIpcServerStart?: (server: AgentIpcServer) => void;
+	private _onIpcMessage?: (message: IpcMessage) => Promise<IpcResponse>;
+	private _onIpcServerStop?: () => void;
 
 	// Tool registry for extension getTools/setTools
 	private _toolRegistry: Map<string, AgentTool> = new Map();
@@ -283,9 +318,15 @@ export class AgentSession {
 		this._customTools = config.customTools ?? [];
 		this._cwd = config.cwd;
 		this._modelRegistry = config.modelRegistry;
+		this._agentRegistry = config.agentRegistry;
 		this._extensionRunnerRef = config.extensionRunnerRef;
 		this._initialActiveToolNames = config.initialActiveToolNames;
 		this._baseToolsOverride = config.baseToolsOverride;
+		this._enableIpc = config.enableIpc ?? false;
+		this._ipcSocketDir = config.ipcSocketDir ?? this._ipcSocketDir;
+		this._onIpcServerStart = config.onIpcServerStart;
+		this._onIpcMessage = config.onIpcMessage;
+		this._onIpcServerStop = config.onIpcServerStop;
 
 		// Always subscribe to agent events for internal handling
 		// (session persistence, extensions, auto-compaction, retry logic)
@@ -295,6 +336,10 @@ export class AgentSession {
 			activeToolNames: this._initialActiveToolNames,
 			includeAllExtensionTools: true,
 		});
+
+		if (this._enableIpc) {
+			void this.startIpcServer();
+		}
 	}
 
 	/** Model registry for API key resolution and model discovery */
@@ -591,8 +636,85 @@ export class AgentSession {
 	 * Call this when completely done with the session.
 	 */
 	dispose(): void {
+		void this.stopIpcServer();
 		this._disconnectFromAgent();
 		this._eventListeners = [];
+	}
+
+	async startIpcServer(): Promise<void> {
+		if (!this._enableIpc || this._ipcServer) {
+			return;
+		}
+
+		this._ipcServer = new AgentIpcServer({
+			sessionId: this.sessionId,
+			socketDir: this._ipcSocketDir,
+			onMessage: async (message) => this._routeIpcMessage(message),
+		});
+		try {
+			await this._ipcServer.start();
+		} catch (error) {
+			this._ipcServer = undefined;
+			throw error;
+		}
+		this._agentDiscovery = new AgentDiscovery({ socketDir: this._ipcSocketDir });
+		this._onIpcServerStart?.(this._ipcServer);
+	}
+
+	async stopIpcServer(): Promise<void> {
+		if (!this._ipcServer) {
+			return;
+		}
+
+		await this._ipcServer.stop();
+		this._ipcServer = undefined;
+		this._agentDiscovery = undefined;
+		this._onIpcServerStop?.();
+	}
+
+	private async _routeIpcMessage(message: IpcMessage): Promise<IpcResponse> {
+		switch (message.type) {
+			case "session.steer": {
+				this.agent.steer(this._createQueuedUserMessage(message.payload.message));
+				return createIpcResponse({
+					id: message.id,
+					success: true,
+					data: { queued: true, queue: "steering" },
+				});
+			}
+			case "session.follow_up": {
+				this.agent.followUp(this._createQueuedUserMessage(message.payload.message));
+				return createIpcResponse({
+					id: message.id,
+					success: true,
+					data: { queued: true, queue: "follow_up" },
+				});
+			}
+			default: {
+				if (this._onIpcMessage) {
+					const response = await this._onIpcMessage(message);
+					return {
+						...response,
+						id: message.id,
+						type: "response",
+						timestamp: response.timestamp ?? new Date().toISOString(),
+					};
+				}
+				return createIpcResponse({
+					id: message.id,
+					success: false,
+					error: `unsupported_ipc_message:${message.type}`,
+				});
+			}
+		}
+	}
+
+	private _createQueuedUserMessage(text: string): AgentMessage {
+		return {
+			role: "user",
+			content: [{ type: "text", text }],
+			timestamp: Date.now(),
+		};
 	}
 
 	// =========================================================================
@@ -699,6 +821,11 @@ export class AgentSession {
 	/** Current session ID */
 	get sessionId(): string {
 		return this.sessionManager.getSessionId();
+	}
+
+	/** IPC socket path for this session (when IPC is enabled). */
+	get ipcSocketPath(): string | undefined {
+		return this._ipcServer?.socketPath;
 	}
 
 	/** Current session display name, if set */
@@ -2045,6 +2172,10 @@ export class AgentSession {
 					})();
 				},
 				getSystemPrompt: () => this.systemPrompt,
+				getAgentRegistry: () => this._agentRegistry,
+				getAgentDiscovery: () => this._agentDiscovery,
+				createIpcClient: (socketPath) => new AgentIpcClient({ socketPath }),
+				runSubAgent: (options) => this.runSubAgent(options),
 			},
 		);
 	}
@@ -2817,6 +2948,177 @@ export class AgentSession {
 	/**
 	 * Get session statistics.
 	 */
+	private _resolveSubAgentModel(modelRef: string, keyOverride?: SubAgentRunOptions["keyOverride"]): Model<any> {
+		const separatorIndex = modelRef.indexOf("/");
+		const parsedProvider = separatorIndex === -1 ? undefined : modelRef.slice(0, separatorIndex);
+		const parsedModelId = separatorIndex === -1 ? modelRef : modelRef.slice(separatorIndex + 1);
+
+		const direct =
+			parsedProvider !== undefined
+				? this.modelRegistry.find(parsedProvider, parsedModelId)
+				: this.modelRegistry.getAll().find((candidate) => candidate.id === parsedModelId);
+		if (!direct) {
+			throw new Error(`Unknown sub-agent model: ${modelRef}`);
+		}
+
+		if (!keyOverride?.baseUrl) {
+			return direct;
+		}
+
+		return {
+			...direct,
+			baseUrl: keyOverride.baseUrl,
+		};
+	}
+
+	private _resolveSubAgentTools(toolNames: string[]): AgentTool[] {
+		if (toolNames.length === 0) {
+			return this.agent.state.tools;
+		}
+
+		const resolved: AgentTool[] = [];
+		for (const toolName of toolNames) {
+			const tool = this._toolRegistry.get(toolName);
+			if (tool) {
+				resolved.push(tool);
+			}
+		}
+		if (resolved.length === 0) {
+			throw new Error(`No valid tools resolved for sub-agent: ${toolNames.join(", ")}`);
+		}
+		return resolved;
+	}
+
+	private _extractAssistantText(message: AssistantMessage | undefined): string {
+		if (!message) {
+			return "";
+		}
+		return message.content
+			.filter(
+				(content): content is Extract<AssistantMessage["content"][number], { type: "text" }> =>
+					content.type === "text",
+			)
+			.map((content) => content.text)
+			.join("")
+			.trim();
+	}
+
+	async runSubAgent(options: SubAgentRunOptions): Promise<SubAgentRunResult> {
+		const sessionId = options.sessionId ?? `sub_${randomUUID()}`;
+		const model = this._resolveSubAgentModel(options.model, options.keyOverride);
+		const tools = this._resolveSubAgentTools(options.tools);
+		const inheritedMessages = options.inheritMessages
+			? this.messages.filter(
+					(message): message is AgentMessage =>
+						message.role === "user" || message.role === "assistant" || message.role === "toolResult",
+				)
+			: [];
+
+		const subAgent = new CoreAgent({
+			sessionId,
+			streamFn: this.agent.streamFn,
+			transport: this.agent.transport,
+			thinkingBudgets: this.agent.thinkingBudgets,
+			maxRetryDelayMs: this.agent.maxRetryDelayMs,
+			getApiKey: async (provider) => {
+				if (options.keyOverride?.provider === provider) {
+					if (options.keyOverride.apiKey) {
+						return options.keyOverride.apiKey;
+					}
+					if (options.keyOverride.envVar) {
+						const envValue = process.env[options.keyOverride.envVar];
+						if (envValue) {
+							return envValue;
+						}
+					}
+				}
+				return this.modelRegistry.getApiKeyForProvider(provider);
+			},
+		});
+
+		subAgent.setModel(model);
+		subAgent.setSystemPrompt(options.systemPrompt);
+		subAgent.setTools(tools);
+		subAgent.setSteeringMode(this.steeringMode);
+		subAgent.setFollowUpMode(this.followUpMode);
+		subAgent.setThinkingLevel(options.thinkingLevel ?? this.thinkingLevel);
+		if (inheritedMessages.length > 0) {
+			subAgent.replaceMessages(inheritedMessages);
+		}
+
+		const taskId = options.taskId ?? sessionId;
+		const unsubscribe =
+			options.ipcForward && this._ipcServer
+				? subAgent.subscribe((event) => {
+						let payload: TaskProgressMessage["payload"] | undefined;
+						switch (event.type) {
+							case "tool_execution_start":
+								payload = {
+									taskId,
+									progressType: "tool_call",
+									message: `Running tool ${event.toolName}`,
+									data: { toolName: event.toolName },
+								};
+								break;
+							case "tool_execution_end":
+								payload = {
+									taskId,
+									progressType: "message",
+									message: event.isError
+										? `Tool ${event.toolName} failed`
+										: `Tool ${event.toolName} completed`,
+									data: { toolName: event.toolName },
+								};
+								break;
+							case "turn_end":
+								payload = {
+									taskId,
+									progressType: "phase_change",
+									message: "Sub-agent completed a turn",
+								};
+								break;
+							case "agent_end":
+								payload = {
+									taskId,
+									progressType: "message",
+									message: "Sub-agent run finished",
+								};
+								break;
+						}
+						if (!payload || !this._ipcServer) {
+							return;
+						}
+						this._ipcServer.broadcast(
+							createIpcMessage<TaskProgressMessage>({
+								type: "task.progress",
+								payload,
+								senderSessionId: this.sessionId,
+							}),
+						);
+					})
+				: undefined;
+
+		try {
+			await subAgent.prompt(options.prompt);
+		} finally {
+			unsubscribe?.();
+		}
+
+		const finalAssistant = subAgent.state.messages
+			.slice()
+			.reverse()
+			.find((message): message is AssistantMessage => message.role === "assistant");
+		const usage = finalAssistant?.usage;
+		return {
+			sessionId,
+			finalText: this._extractAssistantText(finalAssistant),
+			tokenUsage: {
+				input: usage?.input ?? 0,
+				output: usage?.output ?? 0,
+			},
+		};
+	}
+
 	getSessionStats(): SessionStats {
 		const state = this.state;
 		const userMessages = state.messages.filter((m) => m.role === "user").length;

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -20,6 +20,7 @@ export type {
 export { ExtensionRunner } from "./runner.js";
 export type {
 	AgentEndEvent,
+	AgentRegistryAdapter,
 	AgentStartEvent,
 	// Re-exports
 	AgentToolResult,
@@ -123,6 +124,9 @@ export type {
 	SetLabelHandler,
 	SetModelHandler,
 	SetThinkingLevelHandler,
+	SubAgentKeyOverride,
+	SubAgentRunOptions,
+	SubAgentRunResult,
 	TerminalInputHandler,
 	// Events - Tool
 	ToolCallEvent,

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -11,6 +11,7 @@ import type { KeyAction, KeybindingsConfig } from "../keybindings.js";
 import type { ModelRegistry } from "../model-registry.js";
 import type { SessionManager } from "../session-manager.js";
 import type {
+	AgentRegistryAdapter,
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
 	CompactOptions,
@@ -41,6 +42,8 @@ import type {
 	SessionBeforeForkResult,
 	SessionBeforeSwitchResult,
 	SessionBeforeTreeResult,
+	SubAgentRunOptions,
+	SubAgentRunResult,
 	ToolCallEvent,
 	ToolCallEventResult,
 	ToolResultEvent,
@@ -209,6 +212,10 @@ export class ExtensionRunner {
 	private getContextUsageFn: () => ContextUsage | undefined = () => undefined;
 	private compactFn: (options?: CompactOptions) => void = () => {};
 	private getSystemPromptFn: () => string = () => "";
+	private getAgentRegistryFn: () => AgentRegistryAdapter | undefined = () => undefined;
+	private getAgentDiscoveryFn: () => ExtensionContext["agentDiscovery"] | undefined = () => undefined;
+	private createIpcClientFn: ExtensionContext["createIpcClient"] = undefined;
+	private runSubAgentFn: ((options: SubAgentRunOptions) => Promise<SubAgentRunResult>) | undefined = undefined;
 	private newSessionHandler: NewSessionHandler = async () => ({ cancelled: false });
 	private forkHandler: ForkHandler = async () => ({ cancelled: false });
 	private navigateTreeHandler: NavigateTreeHandler = async () => ({ cancelled: false });
@@ -259,6 +266,10 @@ export class ExtensionRunner {
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.compactFn = contextActions.compact;
 		this.getSystemPromptFn = contextActions.getSystemPrompt;
+		this.getAgentRegistryFn = contextActions.getAgentRegistry ?? (() => undefined);
+		this.getAgentDiscoveryFn = contextActions.getAgentDiscovery ?? (() => undefined);
+		this.createIpcClientFn = contextActions.createIpcClient;
+		this.runSubAgentFn = contextActions.runSubAgent;
 
 		// Flush provider registrations queued during extension loading
 		for (const { name, config } of this.runtime.pendingProviderRegistrations) {
@@ -508,6 +519,10 @@ export class ExtensionRunner {
 			cwd: this.cwd,
 			sessionManager: this.sessionManager,
 			modelRegistry: this.modelRegistry,
+			agentRegistry: this.getAgentRegistryFn(),
+			agentDiscovery: this.getAgentDiscoveryFn(),
+			createIpcClient: this.createIpcClientFn,
+			runSubAgent: this.runSubAgentFn,
 			get model() {
 				return getModel();
 			},

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -27,6 +27,7 @@ import type {
 	TextContent,
 	ToolResultMessage,
 } from "@mariozechner/pi-ai";
+import type { AgentDiscovery, AgentIpcClient } from "@mariozechner/pi-ipc";
 import type {
 	AutocompleteItem,
 	Component,
@@ -256,6 +257,45 @@ export interface CompactOptions {
 }
 
 /**
+ * Minimal registry contract exposed to extensions for multi-agent coordination.
+ */
+export interface AgentRegistryAdapter {
+	list(mode?: "primary" | "subagent" | "all", includeAllMode?: boolean): string[];
+	get(name: string): unknown;
+	instantiate?(name: string, model: string): unknown;
+}
+
+export interface SubAgentKeyOverride {
+	provider: string;
+	envVar?: string;
+	apiKey?: string;
+	baseUrl?: string;
+}
+
+export interface SubAgentRunOptions {
+	agentName: string;
+	sessionId?: string;
+	taskId?: string;
+	systemPrompt: string;
+	model: string;
+	tools: string[];
+	prompt: string;
+	thinkingLevel?: ThinkingLevel;
+	inheritMessages?: boolean;
+	ipcForward?: boolean;
+	keyOverride?: SubAgentKeyOverride;
+}
+
+export interface SubAgentRunResult {
+	sessionId: string;
+	finalText: string;
+	tokenUsage: {
+		input: number;
+		output: number;
+	};
+}
+
+/**
  * Context passed to extension event handlers.
  */
 export interface ExtensionContext {
@@ -269,6 +309,14 @@ export interface ExtensionContext {
 	sessionManager: ReadonlySessionManager;
 	/** Model registry for API key resolution */
 	modelRegistry: ModelRegistry;
+	/** Optional multi-agent registry for extension-driven orchestration */
+	agentRegistry?: AgentRegistryAdapter;
+	/** Optional IPC discovery helper for finding alive agent sockets */
+	agentDiscovery?: AgentDiscovery;
+	/** Optional IPC client factory for connecting to discovered sessions */
+	createIpcClient?: (socketPath: string) => AgentIpcClient;
+	/** Optional hook for running sub-agent turns in-process */
+	runSubAgent?: (options: SubAgentRunOptions) => Promise<SubAgentRunResult>;
 	/** Current model (may be undefined) */
 	model: Model<any> | undefined;
 	/** Whether the agent is idle (not streaming) */
@@ -1321,6 +1369,10 @@ export interface ExtensionContextActions {
 	getContextUsage: () => ContextUsage | undefined;
 	compact: (options?: CompactOptions) => void;
 	getSystemPrompt: () => string;
+	getAgentRegistry?: () => AgentRegistryAdapter | undefined;
+	getAgentDiscovery?: () => AgentDiscovery | undefined;
+	createIpcClient?: (socketPath: string) => AgentIpcClient;
+	runSubAgent?: (options: SubAgentRunOptions) => Promise<SubAgentRunResult>;
 }
 
 /**

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -50,6 +50,7 @@ export { createEventBus, type EventBus, type EventBusController } from "./core/e
 // Extension system
 export type {
 	AgentEndEvent,
+	AgentRegistryAdapter,
 	AgentStartEvent,
 	AgentToolResult,
 	AgentToolUpdateCallback,
@@ -108,6 +109,9 @@ export type {
 	SlashCommandInfo,
 	SlashCommandLocation,
 	SlashCommandSource,
+	SubAgentKeyOverride,
+	SubAgentRunOptions,
+	SubAgentRunResult,
 	TerminalInputHandler,
 	ToolCallEvent,
 	ToolDefinition,

--- a/packages/ipc/CHANGELOG.md
+++ b/packages/ipc/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Added initial IPC package scaffold with socket server/client, broker routing, discovery, shared-state storage, and token auth utilities.

--- a/packages/ipc/README.md
+++ b/packages/ipc/README.md
@@ -1,0 +1,30 @@
+# @mariozechner/pi-ipc
+
+IPC transport primitives for pi multi-agent orchestration.
+
+## Included modules
+
+- `AgentIpcServer`: Unix domain socket JSON-RPC server.
+- `AgentIpcClient`: reconnecting client with request/response correlation.
+- `AgentIpcBroker`: in-process message router and pub/sub registry.
+- `AgentDiscovery`: socket directory discovery helpers.
+- `SharedStateManager`: namespaced file-backed shared state.
+- `IpcAuthManager`: HMAC token generation/verification for session messages.
+
+## Usage
+
+```ts
+import { AgentIpcServer, createIpcMessage } from "@mariozechner/pi-ipc";
+
+const server = new AgentIpcServer({
+	sessionId: "ses_demo",
+	onMessage: async (message) => {
+		if (message.type === "session.steer") {
+			return { success: true, data: { accepted: true } };
+		}
+		return { success: false, error: "unsupported" };
+	},
+});
+
+await server.start();
+```

--- a/packages/ipc/package.json
+++ b/packages/ipc/package.json
@@ -1,0 +1,46 @@
+{
+	"name": "@mariozechner/pi-ipc",
+	"version": "0.55.4",
+	"description": "IPC transport layer for pi multi-agent sessions",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"scripts": {
+		"clean": "rm -rf dist",
+		"build": "tsgo -p tsconfig.build.json",
+		"dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
+		"test": "vitest --run",
+		"prepublishOnly": "npm run clean && npm run build"
+	},
+	"keywords": [
+		"ipc",
+		"agent",
+		"socket",
+		"multi-agent"
+	],
+	"author": "Mario Zechner",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/badlogic/pi-mono.git",
+		"directory": "packages/ipc"
+	},
+	"engines": {
+		"node": ">=20.0.0"
+	},
+	"devDependencies": {
+		"@types/node": "^24.3.0",
+		"typescript": "^5.7.3",
+		"vitest": "^3.2.4"
+	}
+}

--- a/packages/ipc/src/auth.ts
+++ b/packages/ipc/src/auth.ts
@@ -1,0 +1,80 @@
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+export interface IpcTokenPayload {
+	sessionId: string;
+	expiresAt: number;
+	nonce: string;
+}
+
+export interface IpcAuthManagerOptions {
+	secret?: string;
+	clock?: () => number;
+}
+
+function encodePayload(payload: IpcTokenPayload): string {
+	return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodePayload(value: string): IpcTokenPayload | null {
+	try {
+		const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as IpcTokenPayload;
+		if (typeof parsed.sessionId !== "string") return null;
+		if (typeof parsed.expiresAt !== "number") return null;
+		if (typeof parsed.nonce !== "string") return null;
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+export class IpcAuthManager {
+	private readonly secret: string;
+	private readonly clock: () => number;
+
+	constructor(options: IpcAuthManagerOptions = {}) {
+		this.secret = options.secret ?? randomBytes(32).toString("hex");
+		this.clock = options.clock ?? (() => Date.now());
+	}
+
+	generateToken(sessionId: string, ttlMs = 60_000): string {
+		const payload: IpcTokenPayload = {
+			sessionId,
+			expiresAt: this.clock() + ttlMs,
+			nonce: randomBytes(12).toString("hex"),
+		};
+
+		const encodedPayload = encodePayload(payload);
+		const signature = this.sign(encodedPayload);
+		return `${encodedPayload}.${signature}`;
+	}
+
+	verifyToken(token: string, expectedSessionId: string): boolean {
+		const separator = token.indexOf(".");
+		if (separator === -1) {
+			return false;
+		}
+
+		const payloadPart = token.slice(0, separator);
+		const signaturePart = token.slice(separator + 1);
+		const expectedSignature = this.sign(payloadPart);
+
+		const provided = Buffer.from(signaturePart);
+		const expected = Buffer.from(expectedSignature);
+		if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+			return false;
+		}
+
+		const payload = decodePayload(payloadPart);
+		if (!payload) {
+			return false;
+		}
+		if (payload.sessionId !== expectedSessionId) {
+			return false;
+		}
+		return payload.expiresAt > this.clock();
+	}
+
+	private sign(payload: string): string {
+		return createHmac("sha256", this.secret).update(payload).digest("base64url");
+	}
+}

--- a/packages/ipc/src/broker.ts
+++ b/packages/ipc/src/broker.ts
@@ -1,0 +1,101 @@
+import { createIpcResponse } from "./messages.js";
+import type { IpcMessage, IpcResponse } from "./types.js";
+
+export type BrokerHandler = (message: IpcMessage) => Promise<IpcResponse | undefined> | IpcResponse | undefined;
+
+interface Subscription {
+	topic: string;
+	sessionId: string;
+	send: (message: IpcMessage) => void;
+}
+
+export class AgentIpcBroker {
+	private readonly handlers = new Map<IpcMessage["type"], BrokerHandler>();
+	private readonly subscriptions = new Map<string, Subscription[]>();
+
+	registerHandler(type: IpcMessage["type"], handler: BrokerHandler): void {
+		this.handlers.set(type, handler);
+	}
+
+	unregisterHandler(type: IpcMessage["type"]): void {
+		this.handlers.delete(type);
+	}
+
+	async route(message: IpcMessage): Promise<IpcResponse> {
+		const handler = this.handlers.get(message.type);
+		if (!handler) {
+			return createIpcResponse({
+				id: message.id,
+				success: false,
+				error: `unhandled_message_type:${message.type}`,
+			});
+		}
+
+		const result = await handler(message);
+		if (result) {
+			return {
+				...result,
+				id: message.id,
+				type: "response",
+				timestamp: result.timestamp ?? new Date().toISOString(),
+			};
+		}
+
+		return createIpcResponse({
+			id: message.id,
+			success: true,
+		});
+	}
+
+	subscribe(topic: string, sessionId: string, send: (message: IpcMessage) => void): () => void {
+		const list = this.subscriptions.get(topic) ?? [];
+		const sub: Subscription = { topic, sessionId, send };
+		list.push(sub);
+		this.subscriptions.set(topic, list);
+
+		return () => {
+			const existing = this.subscriptions.get(topic);
+			if (!existing) {
+				return;
+			}
+			const next = existing.filter((candidate) => candidate !== sub);
+			if (next.length === 0) {
+				this.subscriptions.delete(topic);
+				return;
+			}
+			this.subscriptions.set(topic, next);
+		};
+	}
+
+	publish(topic: string, message: IpcMessage, options?: { excludeSessionId?: string }): number {
+		const listeners = this.subscriptions.get(topic);
+		if (!listeners || listeners.length === 0) {
+			return 0;
+		}
+
+		let delivered = 0;
+		for (const listener of listeners) {
+			if (options?.excludeSessionId && listener.sessionId === options.excludeSessionId) {
+				continue;
+			}
+			listener.send(message);
+			delivered += 1;
+		}
+		return delivered;
+	}
+
+	unsubscribeSession(sessionId: string): void {
+		for (const [topic, listeners] of this.subscriptions.entries()) {
+			const next = listeners.filter((listener) => listener.sessionId !== sessionId);
+			if (next.length === 0) {
+				this.subscriptions.delete(topic);
+			} else {
+				this.subscriptions.set(topic, next);
+			}
+		}
+	}
+
+	getTopics(): string[] {
+		return Array.from(this.subscriptions.keys());
+	}
+}

--- a/packages/ipc/src/client.ts
+++ b/packages/ipc/src/client.ts
@@ -1,0 +1,189 @@
+import { createConnection, type Socket } from "node:net";
+import { setTimeout as delay } from "node:timers/promises";
+import { createIpcResponse } from "./messages.js";
+import type { IpcInboundMessage, IpcMessage, IpcResponse } from "./types.js";
+
+interface PendingRequest {
+	resolve: (response: IpcResponse) => void;
+	reject: (error: Error) => void;
+	timeoutId: NodeJS.Timeout;
+}
+
+export interface AgentIpcClientOptions {
+	socketPath: string;
+	autoReconnect?: boolean;
+	reconnectDelayMs?: number;
+	requestTimeoutMs?: number;
+	onMessage?: (message: IpcMessage) => void;
+}
+
+export class AgentIpcClient {
+	private readonly socketPath: string;
+	private readonly autoReconnect: boolean;
+	private readonly reconnectDelayMs: number;
+	private readonly requestTimeoutMs: number;
+	private readonly onMessage?: (message: IpcMessage) => void;
+
+	private socket?: Socket;
+	private connecting?: Promise<void>;
+	private buffer = "";
+	private reconnecting = false;
+	private readonly pendingRequests = new Map<string, PendingRequest>();
+
+	constructor(options: AgentIpcClientOptions | string) {
+		if (typeof options === "string") {
+			this.socketPath = options;
+			this.autoReconnect = true;
+			this.reconnectDelayMs = 250;
+			this.requestTimeoutMs = 30_000;
+			return;
+		}
+
+		this.socketPath = options.socketPath;
+		this.autoReconnect = options.autoReconnect ?? true;
+		this.reconnectDelayMs = options.reconnectDelayMs ?? 250;
+		this.requestTimeoutMs = options.requestTimeoutMs ?? 30_000;
+		this.onMessage = options.onMessage;
+	}
+
+	async connect(): Promise<void> {
+		if (this.socket && !this.socket.destroyed) {
+			return;
+		}
+		if (this.connecting) {
+			return this.connecting;
+		}
+
+		this.connecting = new Promise<void>((resolve, reject) => {
+			const socket = createConnection(this.socketPath);
+			socket.setEncoding("utf8");
+
+			socket.once("connect", () => {
+				this.socket = socket;
+				this.connecting = undefined;
+				this.attachSocketListeners(socket);
+				resolve();
+			});
+
+			socket.once("error", (error) => {
+				if (this.socket !== socket) {
+					socket.destroy();
+				}
+				this.connecting = undefined;
+				reject(error);
+			});
+		});
+
+		return this.connecting;
+	}
+
+	private attachSocketListeners(socket: Socket): void {
+		socket.on("data", (chunk) => {
+			this.buffer += chunk;
+			let lineEnd = this.buffer.indexOf("\n");
+			while (lineEnd !== -1) {
+				const line = this.buffer.slice(0, lineEnd).trim();
+				this.buffer = this.buffer.slice(lineEnd + 1);
+				if (line.length > 0) {
+					this.handleLine(line);
+				}
+				lineEnd = this.buffer.indexOf("\n");
+			}
+		});
+
+		socket.on("close", () => {
+			this.socket = undefined;
+			this.rejectPendingRequests(new Error("IPC connection closed"));
+			if (this.autoReconnect) {
+				void this.reconnect();
+			}
+		});
+
+		socket.on("error", () => {
+			// no-op; close event handles cleanup
+		});
+	}
+
+	private handleLine(line: string): void {
+		let inbound: IpcInboundMessage;
+		try {
+			inbound = JSON.parse(line) as IpcInboundMessage;
+		} catch {
+			return;
+		}
+
+		if (inbound.type === "response") {
+			const pending = this.pendingRequests.get(inbound.id);
+			if (!pending) {
+				return;
+			}
+			clearTimeout(pending.timeoutId);
+			this.pendingRequests.delete(inbound.id);
+			pending.resolve(inbound);
+			return;
+		}
+
+		this.onMessage?.(inbound);
+	}
+
+	private async reconnect(): Promise<void> {
+		if (this.reconnecting) {
+			return;
+		}
+		this.reconnecting = true;
+		while (this.autoReconnect && !this.isConnected()) {
+			try {
+				await delay(this.reconnectDelayMs);
+				await this.connect();
+				break;
+			} catch {
+				// retry until success or disconnect() disables autoReconnect
+			}
+		}
+		this.reconnecting = false;
+	}
+
+	private rejectPendingRequests(error: Error): void {
+		for (const pending of this.pendingRequests.values()) {
+			clearTimeout(pending.timeoutId);
+			pending.reject(error);
+		}
+		this.pendingRequests.clear();
+	}
+
+	async send(message: IpcMessage): Promise<IpcResponse> {
+		await this.connect();
+		if (!this.socket || this.socket.destroyed) {
+			return createIpcResponse({
+				id: message.id,
+				success: false,
+				error: "ipc_not_connected",
+			});
+		}
+
+		return new Promise<IpcResponse>((resolve, reject) => {
+			const timeoutId = setTimeout(() => {
+				this.pendingRequests.delete(message.id);
+				reject(new Error(`IPC request timed out: ${message.type}`));
+			}, this.requestTimeoutMs);
+
+			this.pendingRequests.set(message.id, { resolve, reject, timeoutId });
+			this.socket?.write(`${JSON.stringify(message)}\n`);
+		});
+	}
+
+	async disconnect(): Promise<void> {
+		this.rejectPendingRequests(new Error("IPC client disconnected"));
+		if (this.socket && !this.socket.destroyed) {
+			await new Promise<void>((resolve) => {
+				this.socket?.once("close", () => resolve());
+				this.socket?.end();
+			});
+		}
+		this.socket = undefined;
+	}
+
+	isConnected(): boolean {
+		return !!this.socket && !this.socket.destroyed;
+	}
+}

--- a/packages/ipc/src/discovery.ts
+++ b/packages/ipc/src/discovery.ts
@@ -1,0 +1,69 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+import { getDefaultSocketDir } from "./server.js";
+import type { AgentDiscoveryRecord } from "./types.js";
+
+function toSessionId(socketPath: string): string {
+	const base = basename(socketPath);
+	return base.endsWith(".sock") ? base.slice(0, -".sock".length) : base;
+}
+
+function readMetadata(socketPath: string): Omit<AgentDiscoveryRecord, "sessionId" | "socketPath" | "updatedAt"> {
+	const metaPath = `${socketPath}.json`;
+	if (!existsSync(metaPath)) {
+		return {};
+	}
+
+	try {
+		const parsed = JSON.parse(readFileSync(metaPath, "utf8")) as Partial<AgentDiscoveryRecord>;
+		return {
+			agentName: parsed.agentName,
+			status: parsed.status,
+			capabilities: parsed.capabilities,
+			currentModel: parsed.currentModel,
+			parentSessionId: parsed.parentSessionId,
+		};
+	} catch {
+		return {};
+	}
+}
+
+export interface AgentDiscoveryOptions {
+	socketDir?: string;
+}
+
+export class AgentDiscovery {
+	private readonly socketDir: string;
+
+	constructor(options: AgentDiscoveryOptions = {}) {
+		this.socketDir = options.socketDir ?? getDefaultSocketDir();
+	}
+
+	listAlive(): AgentDiscoveryRecord[] {
+		if (!existsSync(this.socketDir)) {
+			return [];
+		}
+
+		const files = readdirSync(this.socketDir)
+			.filter((name) => name.endsWith(".sock"))
+			.map((name) => join(this.socketDir, name));
+
+		return files.map((socketPath) => {
+			const stats = statSync(socketPath);
+			return {
+				sessionId: toSessionId(socketPath),
+				socketPath,
+				updatedAt: stats.mtime.toISOString(),
+				...readMetadata(socketPath),
+			};
+		});
+	}
+
+	findBySessionId(sessionId: string): AgentDiscoveryRecord | undefined {
+		return this.listAlive().find((record) => record.sessionId === sessionId);
+	}
+
+	getSocketPath(sessionId: string): string | undefined {
+		return this.findBySessionId(sessionId)?.socketPath;
+	}
+}

--- a/packages/ipc/src/index.ts
+++ b/packages/ipc/src/index.ts
@@ -1,0 +1,33 @@
+export { IpcAuthManager, type IpcAuthManagerOptions, type IpcTokenPayload } from "./auth.js";
+export { AgentIpcBroker, type BrokerHandler } from "./broker.js";
+export { AgentIpcClient, type AgentIpcClientOptions } from "./client.js";
+export { AgentDiscovery, type AgentDiscoveryOptions } from "./discovery.js";
+export { createIpcEnvelope, createIpcMessage, createIpcResponse, generateIpcMessageId } from "./messages.js";
+export { AgentIpcServer, type AgentIpcServerOptions, getDefaultSocketDir } from "./server.js";
+export { SharedStateManager, type SharedStateManagerOptions, type SharedStateRecord } from "./shared-state.js";
+export type {
+	AgentCapabilityAnnounceMessage,
+	AgentDiscoveryRecord,
+	AgentHandshakeMessage,
+	AgentHeartbeatMessage,
+	BrokerBroadcastMessage,
+	BrokerDiscoverMessage,
+	BrokerRegisterMessage,
+	IpcEventHandler,
+	IpcInboundMessage,
+	IpcMessage,
+	IpcMessageBase,
+	IpcMessageType,
+	IpcRequestHandler,
+	IpcResponse,
+	IpcSocketInfo,
+	PubSubPublishMessage,
+	PubSubSubscribeMessage,
+	SessionFollowUpMessage,
+	SessionSteerMessage,
+	StateQueryMessage,
+	StateSyncMessage,
+	TaskDelegateMessage,
+	TaskProgressMessage,
+	TaskResultMessage,
+} from "./types.js";

--- a/packages/ipc/src/messages.ts
+++ b/packages/ipc/src/messages.ts
@@ -1,0 +1,45 @@
+import { randomUUID } from "node:crypto";
+import type { IpcMessage, IpcMessageBase, IpcResponse } from "./types.js";
+
+export function generateIpcMessageId(): string {
+	return randomUUID();
+}
+
+export function createIpcEnvelope<TType extends IpcMessageBase["type"]>(
+	type: TType,
+	options?: Pick<IpcMessageBase, "senderSessionId" | "authToken">,
+): Pick<IpcMessageBase, "id" | "timestamp" | "type" | "senderSessionId" | "authToken"> {
+	return {
+		id: generateIpcMessageId(),
+		timestamp: new Date().toISOString(),
+		type,
+		senderSessionId: options?.senderSessionId,
+		authToken: options?.authToken,
+	};
+}
+
+export function createIpcMessage<TMessage extends IpcMessage>(message: Omit<TMessage, "id" | "timestamp">): TMessage {
+	return {
+		...message,
+		id: generateIpcMessageId(),
+		timestamp: new Date().toISOString(),
+	} as TMessage;
+}
+
+export function createIpcResponse(options: {
+	id?: string;
+	success: boolean;
+	data?: unknown;
+	error?: string;
+	senderSessionId?: string;
+}): IpcResponse {
+	return {
+		id: options.id ?? generateIpcMessageId(),
+		type: "response",
+		timestamp: new Date().toISOString(),
+		success: options.success,
+		data: options.data,
+		error: options.error,
+		senderSessionId: options.senderSessionId,
+	};
+}

--- a/packages/ipc/src/server.ts
+++ b/packages/ipc/src/server.ts
@@ -1,0 +1,186 @@
+import { chmodSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { createServer, type Server, type Socket } from "node:net";
+import { basename, dirname, join } from "node:path";
+import { createIpcResponse } from "./messages.js";
+import type { IpcInboundMessage, IpcMessage, IpcRequestHandler, IpcResponse } from "./types.js";
+
+export interface AgentIpcServerOptions {
+	sessionId: string;
+	onMessage: IpcRequestHandler;
+	socketDir?: string;
+	socketPath?: string;
+	onClientMessage?: (message: IpcMessage) => void;
+}
+
+function defaultSocketDir(): string {
+	return join(process.env.HOME ?? process.cwd(), ".pi", "agent", "sockets");
+}
+
+function deriveSocketPath(sessionId: string, socketDir?: string): string {
+	return join(socketDir ?? defaultSocketDir(), `${sessionId}.sock`);
+}
+
+function parseMessage(raw: string): IpcInboundMessage | null {
+	try {
+		const parsed = JSON.parse(raw) as unknown;
+		if (typeof parsed !== "object" || parsed === null) {
+			return null;
+		}
+		return parsed as IpcInboundMessage;
+	} catch {
+		return null;
+	}
+}
+
+function writeLine(socket: Socket, payload: unknown): void {
+	socket.write(`${JSON.stringify(payload)}\n`);
+}
+
+export class AgentIpcServer {
+	readonly sessionId: string;
+	readonly socketPath: string;
+
+	private readonly onMessage: IpcRequestHandler;
+	private readonly onClientMessage?: (message: IpcMessage) => void;
+	private readonly sockets = new Set<Socket>();
+	private server?: Server;
+
+	constructor(options: AgentIpcServerOptions) {
+		this.sessionId = options.sessionId;
+		this.socketPath = options.socketPath ?? deriveSocketPath(options.sessionId, options.socketDir);
+		this.onMessage = options.onMessage;
+		this.onClientMessage = options.onClientMessage;
+	}
+
+	async start(): Promise<void> {
+		if (this.server) {
+			return;
+		}
+
+		const socketDir = dirname(this.socketPath);
+		if (!existsSync(socketDir)) {
+			mkdirSync(socketDir, { recursive: true, mode: 0o700 });
+		}
+
+		if (existsSync(this.socketPath)) {
+			rmSync(this.socketPath, { force: true });
+		}
+
+		this.server = createServer((socket) => this.handleConnection(socket));
+		await new Promise<void>((resolve, reject) => {
+			this.server?.once("error", reject);
+			this.server?.listen(this.socketPath, () => resolve());
+		});
+		chmodSync(this.socketPath, 0o600);
+	}
+
+	private handleConnection(socket: Socket): void {
+		this.sockets.add(socket);
+		socket.setEncoding("utf8");
+
+		let buffer = "";
+		socket.on("data", (chunk) => {
+			buffer += chunk;
+			let lineEnd = buffer.indexOf("\n");
+			while (lineEnd !== -1) {
+				const line = buffer.slice(0, lineEnd).trim();
+				buffer = buffer.slice(lineEnd + 1);
+				if (line.length > 0) {
+					void this.handleMessageLine(line, socket);
+				}
+				lineEnd = buffer.indexOf("\n");
+			}
+		});
+
+		socket.on("close", () => {
+			this.sockets.delete(socket);
+		});
+		socket.on("error", () => {
+			this.sockets.delete(socket);
+		});
+	}
+
+	private async handleMessageLine(line: string, socket: Socket): Promise<void> {
+		const inbound = parseMessage(line);
+		if (!inbound) {
+			writeLine(
+				socket,
+				createIpcResponse({
+					success: false,
+					error: "invalid_json",
+				}),
+			);
+			return;
+		}
+
+		if (inbound.type === "response") {
+			return;
+		}
+
+		this.onClientMessage?.(inbound);
+		let response: IpcResponse;
+		try {
+			const result = await this.onMessage(inbound);
+			response = {
+				...createIpcResponse({
+					id: inbound.id,
+					success: result.success,
+					data: result.data,
+					error: result.error,
+				}),
+			};
+		} catch (error) {
+			response = createIpcResponse({
+				id: inbound.id,
+				success: false,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+
+		writeLine(socket, response);
+	}
+
+	async stop(): Promise<void> {
+		for (const socket of this.sockets) {
+			socket.destroy();
+		}
+		this.sockets.clear();
+
+		if (this.server) {
+			await new Promise<void>((resolve) => {
+				this.server?.close(() => resolve());
+			});
+			this.server = undefined;
+		}
+
+		if (existsSync(this.socketPath)) {
+			rmSync(this.socketPath, { force: true });
+		}
+	}
+
+	broadcast(message: IpcMessage): void {
+		for (const socket of this.sockets) {
+			if (socket.destroyed) {
+				continue;
+			}
+			writeLine(socket, message);
+		}
+	}
+
+	isRunning(): boolean {
+		return this.server?.listening ?? false;
+	}
+
+	toJSON(): { sessionId: string; socketPath: string; socketName: string; clientCount: number } {
+		return {
+			sessionId: this.sessionId,
+			socketPath: this.socketPath,
+			socketName: basename(this.socketPath),
+			clientCount: this.sockets.size,
+		};
+	}
+}
+
+export function getDefaultSocketDir(): string {
+	return defaultSocketDir();
+}

--- a/packages/ipc/src/shared-state.ts
+++ b/packages/ipc/src/shared-state.ts
@@ -1,0 +1,83 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+function ensureDir(path: string): void {
+	if (!existsSync(path)) {
+		mkdirSync(path, { recursive: true, mode: 0o700 });
+	}
+}
+
+function namespacePath(baseDir: string, namespace: string): string {
+	return join(baseDir, namespace);
+}
+
+function entryPath(baseDir: string, namespace: string, key: string): string {
+	return join(namespacePath(baseDir, namespace), `${key}.json`);
+}
+
+export interface SharedStateRecord<TValue = unknown> {
+	namespace: string;
+	key: string;
+	value: TValue;
+	updatedAt: string;
+	updatedBy?: string;
+}
+
+export interface SharedStateManagerOptions {
+	baseDir: string;
+}
+
+export class SharedStateManager {
+	private readonly baseDir: string;
+
+	constructor(options: SharedStateManagerOptions) {
+		this.baseDir = options.baseDir;
+		ensureDir(this.baseDir);
+	}
+
+	write<TValue>(namespace: string, key: string, value: TValue, updatedBy?: string): SharedStateRecord<TValue> {
+		const namespaceDir = namespacePath(this.baseDir, namespace);
+		ensureDir(namespaceDir);
+		const record: SharedStateRecord<TValue> = {
+			namespace,
+			key,
+			value,
+			updatedAt: new Date().toISOString(),
+			updatedBy,
+		};
+		writeFileSync(entryPath(this.baseDir, namespace, key), JSON.stringify(record, null, "\t"));
+		return record;
+	}
+
+	read<TValue>(namespace: string, key: string): SharedStateRecord<TValue> | undefined {
+		const path = entryPath(this.baseDir, namespace, key);
+		if (!existsSync(path)) {
+			return undefined;
+		}
+		try {
+			return JSON.parse(readFileSync(path, "utf8")) as SharedStateRecord<TValue>;
+		} catch {
+			return undefined;
+		}
+	}
+
+	update<TValue>(
+		namespace: string,
+		key: string,
+		updater: (current: TValue | undefined) => TValue,
+		updatedBy?: string,
+	): SharedStateRecord<TValue> {
+		const current = this.read<TValue>(namespace, key)?.value;
+		const next = updater(current);
+		return this.write(namespace, key, next, updatedBy);
+	}
+
+	delete(namespace: string, key: string): boolean {
+		const path = entryPath(this.baseDir, namespace, key);
+		if (!existsSync(path)) {
+			return false;
+		}
+		rmSync(path, { force: true });
+		return true;
+	}
+}

--- a/packages/ipc/src/types.ts
+++ b/packages/ipc/src/types.ts
@@ -1,0 +1,249 @@
+export type IpcMessageType =
+	| "agent.handshake"
+	| "agent.heartbeat"
+	| "task.delegate"
+	| "task.result"
+	| "task.progress"
+	| "state.sync"
+	| "state.query"
+	| "session.steer"
+	| "session.follow_up"
+	| "agent.capability_announce"
+	| "broker.register"
+	| "broker.discover"
+	| "broker.broadcast"
+	| "pubsub.subscribe"
+	| "pubsub.publish"
+	| "response";
+
+export interface IpcMessageBase {
+	id: string;
+	timestamp: string;
+	type: IpcMessageType;
+	senderSessionId?: string;
+	authToken?: string;
+}
+
+export interface AgentHandshakeMessage extends IpcMessageBase {
+	type: "agent.handshake";
+	payload: {
+		sessionId: string;
+		agentName: string;
+		capabilities: string[];
+		socketPath: string;
+		currentModel: string;
+		parentSessionId?: string;
+		token: string;
+	};
+}
+
+export interface AgentHeartbeatMessage extends IpcMessageBase {
+	type: "agent.heartbeat";
+	payload: {
+		sessionId: string;
+		status: "idle" | "running" | "busy";
+		currentTaskId?: string;
+		memoryMB?: number;
+		contextUsage?: number;
+	};
+}
+
+export interface TaskDelegateMessage extends IpcMessageBase {
+	type: "task.delegate";
+	payload: {
+		taskId: string;
+		sessionId: string;
+		agentName?: string;
+		category?: string;
+		prompt: string;
+		model?: string;
+		skills?: string[];
+		parentSessionId: string;
+		timeoutMs?: number;
+		priority?: "low" | "normal" | "high" | "critical";
+	};
+}
+
+export interface TaskResultMessage extends IpcMessageBase {
+	type: "task.result";
+	payload: {
+		taskId: string;
+		sessionId: string;
+		success: boolean;
+		output: string;
+		error?: string;
+		changedFiles?: string[];
+		tokenUsage: {
+			input: number;
+			output: number;
+			cacheRead?: number;
+			cacheWrite?: number;
+		};
+		durationMs: number;
+		subTaskIds?: string[];
+	};
+}
+
+export interface TaskProgressMessage extends IpcMessageBase {
+	type: "task.progress";
+	payload: {
+		taskId: string;
+		progressType: "tool_call" | "llm_thinking" | "file_modified" | "subtask_delegated" | "phase_change" | "message";
+		message: string;
+		data?: {
+			toolName?: string;
+			filePath?: string;
+			subTaskId?: string;
+			phase?: string;
+			percentComplete?: number;
+		};
+		tokenCount?: number;
+	};
+}
+
+export interface StateSyncMessage extends IpcMessageBase {
+	type: "state.sync";
+	payload: {
+		namespace: string;
+		key: string;
+		operation: "create" | "update" | "delete";
+		value?: unknown;
+		modifiedBy: string;
+	};
+}
+
+export interface StateQueryMessage extends IpcMessageBase {
+	type: "state.query";
+	payload: {
+		namespace: string;
+		key: string;
+	};
+}
+
+export interface SessionSteerMessage extends IpcMessageBase {
+	type: "session.steer";
+	payload: {
+		targetSessionId: string;
+		message: string;
+		mode?: "all" | "one-at-a-time";
+		priority?: "normal" | "high" | "urgent";
+		token: string;
+	};
+}
+
+export interface SessionFollowUpMessage extends IpcMessageBase {
+	type: "session.follow_up";
+	payload: {
+		targetSessionId: string;
+		message: string;
+		mode?: "all" | "one-at-a-time";
+		token: string;
+	};
+}
+
+export interface AgentCapabilityAnnounceMessage extends IpcMessageBase {
+	type: "agent.capability_announce";
+	payload: {
+		sessionId: string;
+		agentName: string;
+		capabilities: string[];
+		loadedSkills: string[];
+		availableSlots: number;
+		status: "idle" | "running" | "busy";
+		currentModel: string;
+		contextAvailability: number;
+	};
+}
+
+export interface BrokerRegisterMessage extends IpcMessageBase {
+	type: "broker.register";
+	payload: {
+		sessionId: string;
+		agentName: string;
+		socketPath: string;
+		capabilities: string[];
+	};
+}
+
+export interface BrokerDiscoverMessage extends IpcMessageBase {
+	type: "broker.discover";
+	payload: {
+		agentName?: string;
+		capability?: string;
+		status?: "idle" | "running" | "busy";
+	};
+}
+
+export interface BrokerBroadcastMessage extends IpcMessageBase {
+	type: "broker.broadcast";
+	payload: {
+		message: string;
+		topic?: string;
+		data?: unknown;
+		excludeSelf?: boolean;
+	};
+}
+
+export interface PubSubSubscribeMessage extends IpcMessageBase {
+	type: "pubsub.subscribe";
+	payload: {
+		topics: string[];
+		subscriberSessionId: string;
+		callbackSocketPath: string;
+	};
+}
+
+export interface PubSubPublishMessage extends IpcMessageBase {
+	type: "pubsub.publish";
+	payload: {
+		topic: string;
+		data: unknown;
+		publisherSessionId: string;
+	};
+}
+
+export interface IpcResponse extends IpcMessageBase {
+	type: "response";
+	success: boolean;
+	data?: unknown;
+	error?: string;
+}
+
+export type IpcMessage =
+	| AgentHandshakeMessage
+	| AgentHeartbeatMessage
+	| TaskDelegateMessage
+	| TaskResultMessage
+	| TaskProgressMessage
+	| StateSyncMessage
+	| StateQueryMessage
+	| SessionSteerMessage
+	| SessionFollowUpMessage
+	| AgentCapabilityAnnounceMessage
+	| BrokerRegisterMessage
+	| BrokerDiscoverMessage
+	| BrokerBroadcastMessage
+	| PubSubSubscribeMessage
+	| PubSubPublishMessage;
+
+export type IpcInboundMessage = IpcMessage | IpcResponse;
+
+export type IpcRequestHandler = (
+	message: IpcMessage,
+) => Promise<IpcResponse | Omit<IpcResponse, "id" | "timestamp" | "type">>;
+
+export type IpcEventHandler = (message: IpcMessage) => void;
+
+export interface IpcSocketInfo {
+	sessionId: string;
+	socketPath: string;
+	updatedAt: string;
+}
+
+export interface AgentDiscoveryRecord extends IpcSocketInfo {
+	agentName?: string;
+	status?: "idle" | "running" | "busy";
+	capabilities?: string[];
+	currentModel?: string;
+	parentSessionId?: string;
+}

--- a/packages/ipc/test/broker.test.ts
+++ b/packages/ipc/test/broker.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import { AgentIpcBroker } from "../src/broker.js";
+import { createIpcMessage } from "../src/messages.js";
+import type { PubSubPublishMessage, SessionFollowUpMessage } from "../src/types.js";
+
+describe("AgentIpcBroker", () => {
+	test("routes messages to registered handlers", async () => {
+		const broker = new AgentIpcBroker();
+		broker.registerHandler("session.follow_up", async (message) => {
+			if (message.type !== "session.follow_up") {
+				return;
+			}
+			return {
+				id: message.id,
+				type: "response",
+				timestamp: new Date().toISOString(),
+				success: true,
+				data: { queued: message.payload.message },
+			};
+		});
+
+		const response = await broker.route(
+			createIpcMessage<SessionFollowUpMessage>({
+				type: "session.follow_up",
+				payload: {
+					targetSessionId: "ses_123",
+					message: "next step",
+					token: "token",
+				},
+			}),
+		);
+
+		expect(response.success).toBe(true);
+		expect(response.data).toEqual({ queued: "next step" });
+	});
+
+	test("supports pub/sub fanout", () => {
+		const broker = new AgentIpcBroker();
+		const delivered: string[] = [];
+		const unsubscribe = broker.subscribe("state_change", "ses_a", () => {
+			delivered.push("a");
+		});
+		broker.subscribe("state_change", "ses_b", () => {
+			delivered.push("b");
+		});
+
+		const count = broker.publish(
+			"state_change",
+			createIpcMessage<PubSubPublishMessage>({
+				type: "pubsub.publish",
+				payload: {
+					topic: "state_change",
+					data: { key: "tasks" },
+					publisherSessionId: "ses_orchestrator",
+				},
+			}),
+			{ excludeSessionId: "ses_b" },
+		);
+
+		expect(count).toBe(1);
+		expect(delivered).toEqual(["a"]);
+
+		unsubscribe();
+		expect(broker.getTopics()).toEqual(["state_change"]);
+	});
+});

--- a/packages/ipc/test/discovery.test.ts
+++ b/packages/ipc/test/discovery.test.ts
@@ -1,0 +1,35 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { AgentDiscovery } from "../src/discovery.js";
+
+const cleanupPaths: string[] = [];
+
+afterEach(() => {
+	for (const path of cleanupPaths.splice(0)) {
+		rmSync(path, { recursive: true, force: true });
+	}
+});
+
+describe("AgentDiscovery", () => {
+	test("discovers alive sessions from socket directory", () => {
+		const socketDir = mkdtempSync(join(tmpdir(), "pi-discovery-"));
+		cleanupPaths.push(socketDir);
+
+		mkdirSync(socketDir, { recursive: true });
+		writeFileSync(join(socketDir, "ses_alpha.sock"), "");
+		writeFileSync(
+			join(socketDir, "ses_alpha.sock.json"),
+			JSON.stringify({ agentName: "oracle", status: "idle", currentModel: "anthropic/claude-sonnet-4-5" }),
+		);
+
+		const discovery = new AgentDiscovery({ socketDir });
+		const records = discovery.listAlive();
+
+		expect(records).toHaveLength(1);
+		expect(records[0].sessionId).toBe("ses_alpha");
+		expect(records[0].agentName).toBe("oracle");
+		expect(discovery.getSocketPath("ses_alpha")).toContain("ses_alpha.sock");
+	});
+});

--- a/packages/ipc/test/server-client.test.ts
+++ b/packages/ipc/test/server-client.test.ts
@@ -1,0 +1,100 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { AgentIpcClient } from "../src/client.js";
+import { createIpcMessage } from "../src/messages.js";
+import { AgentIpcServer } from "../src/server.js";
+import type { SessionSteerMessage, TaskProgressMessage } from "../src/types.js";
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+	for (const path of cleanupPaths.splice(0)) {
+		rmSync(path, { recursive: true, force: true });
+	}
+});
+
+describe("AgentIpcServer/AgentIpcClient", () => {
+	test("handles request/response messaging", async () => {
+		const socketDir = mkdtempSync(join(tmpdir(), "pi-ipc-"));
+		cleanupPaths.push(socketDir);
+
+		const server = new AgentIpcServer({
+			sessionId: "ses_server",
+			socketDir,
+			onMessage: async (message) => {
+				if (message.type === "session.steer") {
+					return {
+						success: true,
+						data: { accepted: true, message: message.payload.message },
+					};
+				}
+				return { success: false, error: "unsupported" };
+			},
+		});
+		await server.start();
+
+		const client = new AgentIpcClient({ socketPath: server.socketPath, autoReconnect: false });
+		await client.connect();
+
+		const response = await client.send(
+			createIpcMessage<SessionSteerMessage>({
+				type: "session.steer",
+				payload: {
+					targetSessionId: "ses_server",
+					message: "pause current branch",
+					token: "token",
+				},
+			}),
+		);
+
+		expect(response.success).toBe(true);
+		expect(response.data).toEqual({ accepted: true, message: "pause current branch" });
+
+		await client.disconnect();
+		await server.stop();
+	});
+
+	test("broadcasts events to connected clients", async () => {
+		const socketDir = mkdtempSync(join(tmpdir(), "pi-ipc-"));
+		cleanupPaths.push(socketDir);
+
+		const server = new AgentIpcServer({
+			sessionId: "ses_server",
+			socketDir,
+			onMessage: async () => ({ success: true }),
+		});
+		await server.start();
+
+		let received: TaskProgressMessage | undefined;
+		const client = new AgentIpcClient({
+			socketPath: server.socketPath,
+			autoReconnect: false,
+			onMessage: (message) => {
+				if (message.type === "task.progress") {
+					received = message;
+				}
+			},
+		});
+		await client.connect();
+
+		server.broadcast(
+			createIpcMessage<TaskProgressMessage>({
+				type: "task.progress",
+				payload: {
+					taskId: "task_1",
+					progressType: "message",
+					message: "still running",
+				},
+			}),
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(received?.payload.taskId).toBe("task_1");
+		expect(received?.payload.message).toBe("still running");
+
+		await client.disconnect();
+		await server.stop();
+	});
+});

--- a/packages/ipc/tsconfig.build.json
+++ b/packages/ipc/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "dist", "**/*.d.ts", "src/**/*.d.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,8 @@
 			"@mariozechner/pi-coding-agent": ["./packages/coding-agent/src/index.ts"],
 			"@mariozechner/pi-coding-agent/hooks": ["./packages/coding-agent/src/core/hooks/index.ts"],
 			"@mariozechner/pi-coding-agent/*": ["./packages/coding-agent/src/*"],
+			"@mariozechner/pi-ipc": ["./packages/ipc/src/index.ts"],
+			"@mariozechner/pi-ipc/*": ["./packages/ipc/src/*"],
 			"@sinclair/typebox": ["./node_modules/@sinclair/typebox"],
 			"@mariozechner/pi-mom": ["./packages/mom/src/index.ts"],
 			"@mariozechner/pi-mom/*": ["./packages/mom/src/*"],
@@ -21,10 +23,18 @@
 			"@mariozechner/pi-tui/*": ["./packages/tui/src/*"],
 			"@mariozechner/pi-web-ui": ["./packages/web-ui/src/index.ts"],
 			"@mariozechner/pi-web-ui/*": ["./packages/web-ui/src/*"],
+			"@pi/multi-agent": ["./extensions/multi-agent/src/index.ts"],
+			"@pi/multi-agent/*": ["./extensions/multi-agent/src/*"],
 			"@mariozechner/pi-agent-old": ["./packages/agent-old/src/index.ts"],
 			"@mariozechner/pi-agent-old/*": ["./packages/agent-old/src/*"]
 		}
 	},
-	"include": ["packages/*/src/**/*", "packages/*/test/**/*", "packages/coding-agent/examples/**/*"],
+	"include": [
+		"packages/*/src/**/*",
+		"packages/*/test/**/*",
+		"packages/coding-agent/examples/**/*",
+		"extensions/*/src/**/*",
+		"extensions/*/test/**/*"
+	],
 	"exclude": ["packages/web-ui/**/*", "**/dist/**"]
 }


### PR DESCRIPTION
## Summary
Implements the issue #14 canonical docs in phased slices, with **Phase-1 completed** and a **Phase-2 follow-up slice** now included.

Delivered in this PR so far:
- `packages/ipc` scaffold + tests
- `extensions/multi-agent` registry/routing/task tooling + tests
- `packages/coding-agent` minimal IPC/sub-agent hooks
- Phase-2 partial: remote IPC task delegation path + mesh commands + additional agents

## Canonical-doc checklist (completed)

### Phase 1 baseline
- [x] Create `packages/ipc` package scaffold with:
  - [x] `src/types.ts`
  - [x] `src/messages.ts`
  - [x] `src/server.ts` (UDS JSON-line IPC server)
  - [x] `src/client.ts` (request/response client with reconnect support)
  - [x] `src/broker.ts` (message routing + pub/sub)
  - [x] `src/discovery.ts` (socket directory discovery)
  - [x] `src/shared-state.ts` (file-backed shared state manager)
  - [x] `src/auth.ts` (token signing/verification)
  - [x] `src/index.ts` exports
- [x] Add IPC package tests:
  - [x] `test/server-client.test.ts`
  - [x] `test/broker.test.ts`
  - [x] `test/discovery.test.ts`
- [x] Add `extensions/multi-agent` package with:
  - [x] Agent registry (`registry/AgentRegistry.ts`, `registry/types.ts`)
  - [x] Routing layer (`routing/CategoryRouter.ts`, `routing/ModelRouter.ts`, `routing/FallbackChain.ts`, `routing/types.ts`)
  - [x] Dynamic prompt builder (`prompts/DynamicPromptBuilder.ts`)
  - [x] Built-in agents: `sisyphus`, `sisyphus-junior`, `oracle`, `explore`
  - [x] Delegation orchestrator (`orchestration/TaskDelegator.ts`)
  - [x] Tools: `task`, `background_output`/`background_cancel`, `shared_state`
  - [x] Extension entrypoint wiring (`src/index.ts`)
- [x] Add multi-agent extension tests:
  - [x] `test/model-router.test.ts`
  - [x] `test/task-delegator.test.ts`
- [x] Apply coding-agent minimal hook changes:
  - [x] `AgentSessionConfig` IPC hooks (`enableIpc`, `ipcSocketDir`, lifecycle callbacks)
  - [x] IPC server lifecycle in `AgentSession` (`startIpcServer` / `stopIpcServer`)
  - [x] Basic IPC routing for `session.steer` and `session.follow_up`
  - [x] `runSubAgent()` implementation in `AgentSession`
  - [x] Extension context expansion for `agentRegistry`, `agentDiscovery`, `createIpcClient`, `runSubAgent`
  - [x] Extension runner plumbing for new context actions
- [x] Workspace/build wiring:
  - [x] Root workspaces include `extensions/*`
  - [x] Root build script includes `packages/ipc` and `extensions/multi-agent`
  - [x] Root tsconfig paths/includes updated for new package/extension
- [x] Phase-1 docs delivered:
  - [x] `packages/ipc/README.md`
  - [x] `packages/ipc/CHANGELOG.md`
  - [x] `extensions/multi-agent/README.md`

### Phase 2 partial follow-up now delivered
- [x] `AgentIpcServer` writes/updates/removes discovery metadata (`.sock.json`)
- [x] `AgentSession` handles `task.delegate` IPC message and emits `task.result`
- [x] `TaskDelegator` can route agent-targeted tasks to discovered remote sessions over IPC
- [x] Added mesh-oriented commands in multi-agent extension:
  - [x] `agent.discover`
  - [x] `agent.send`
  - [x] `agent.steer`
  - [x] `agent.subscribe`
  - [x] `session.mesh.status`
  - [x] `agent.list_models` / `agent.list_available_models`
- [x] Added additional built-in agents from phase roadmap:
  - [x] `hephaestus`
  - [x] `librarian`
  - [x] `metis`
  - [x] `prometheus`

## Canonical-doc checklist (still pending)

### Remaining Phase 2
- [ ] Full `agent.*` RPC namespace wiring through existing RPC transport layer (beyond extension command handlers)
- [ ] Atlas orchestration workflow (Todo/QA gate) and production-ready multi-process orchestration semantics from DOC-A
- [ ] Complete shared-state lock protocol and richer pub/sub broker flow integration

### Phase 3 (production hardening)
- [ ] TUI multi-agent panel + mesh visualization/progress UX
- [ ] Security hardening from docs (session-token handshake enforcement, rate limiting, etc.)
- [ ] Observability/metrics/export enhancements
- [ ] Hashline Edit coexistence package/path

## Validation run
- `npm run check`
- `npx tsgo -p packages/ipc/tsconfig.build.json`
- `npx tsgo -p packages/coding-agent/tsconfig.build.json`
- `npx tsgo -p extensions/multi-agent/tsconfig.build.json`
- `cd packages/ipc && npx tsx ../../node_modules/vitest/dist/cli.js --run test/server-client.test.ts test/broker.test.ts test/discovery.test.ts`
- `cd extensions/multi-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/model-router.test.ts test/task-delegator.test.ts`

## Notes
This PR continues to land source-doc slices incrementally in the same branch/PR, with explicit completed vs pending traceability to the issue docs.
