### PR TITLE
feat: phase-2 multi-agent IPC/RPC continuation for issue #14

### DIFF
--- a/extensions/multi-agent/README.md
+++ b/extensions/multi-agent/README.md
@@ -10,6 +10,12 @@ Phase-1 multi-agent foundation extension.
 - IPC-aware remote delegation path (`task.delegate`) when discovered peer agents are available
 - Lightweight dynamic prompt builder for orchestrator prompts
 - Agent mesh commands: `/agent.discover`, `/agent.send`, `/agent.steer`, `/agent.subscribe`, `/session.mesh.status`
+- Agent model routing commands: `/agent.list_models`, `/agent.get_model`, `/agent.set_model`, `/agent.set_provider`, `/agent.reset_model`, `/agent.list_available_models`
+
+## RPC command coverage (when extension is loaded)
+
+- Mesh: `agent.discover`, `agent.send`, `agent.steer`, `agent.subscribe`, `session.mesh.status`
+- Model routing: `agent.list_models`, `agent.get_model`, `agent.set_model`, `agent.set_provider`, `agent.reset_model`, `agent.list_available_models`
 
 ## Settings
 

--- a/extensions/multi-agent/README.md
+++ b/extensions/multi-agent/README.md
@@ -4,10 +4,12 @@ Phase-1 multi-agent foundation extension.
 
 ## Included in this slice
 
-- Agent registry and built-in agent factories (`sisyphus`, `sisyphus-junior`, `oracle`, `explore`)
+- Agent registry and built-in agent factories (`sisyphus`, `sisyphus-junior`, `oracle`, `explore`, `hephaestus`, `librarian`, `metis`, `prometheus`)
 - Category/model routing via `ModelRouter`
 - `task` tool for in-process sub-agent delegation via `ctx.runSubAgent`
+- IPC-aware remote delegation path (`task.delegate`) when discovered peer agents are available
 - Lightweight dynamic prompt builder for orchestrator prompts
+- Agent mesh commands: `/agent.discover`, `/agent.send`, `/agent.steer`, `/agent.subscribe`, `/session.mesh.status`
 
 ## Settings
 

--- a/extensions/multi-agent/src/agents/hephaestus.ts
+++ b/extensions/multi-agent/src/agents/hephaestus.ts
@@ -1,0 +1,17 @@
+import type { AgentConfig, AgentFactory } from "../registry/types.js";
+
+export const hephaestusFactory: AgentFactory = Object.assign(
+	(model: string): AgentConfig => ({
+		name: "hephaestus",
+		description: "Deep implementation worker for complex multi-step coding tasks.",
+		whenToUse: "Use for high-effort implementation, large refactors, and debugging loops.",
+		systemPrompt: [
+			"You are Hephaestus, an autonomous deep-work engineering agent.",
+			"Execute multi-step implementation plans with explicit validation checkpoints.",
+			`Active model: ${model}`,
+		].join("\n"),
+		tools: ["read", "bash", "edit", "write", "grep", "find", "ls", "task", "background_output"],
+		defaultThinkingLevel: "xhigh",
+	}),
+	{ mode: "all" as const },
+);

--- a/extensions/multi-agent/src/agents/index.ts
+++ b/extensions/multi-agent/src/agents/index.ts
@@ -2,6 +2,10 @@ import { createSisyphusFactory } from "./sisyphus.js";
 import { sisyphusJuniorFactory } from "./sisyphus-junior.js";
 import { oracleFactory } from "./oracle.js";
 import { exploreFactory } from "./explore.js";
+import { hephaestusFactory } from "./hephaestus.js";
+import { librarianFactory } from "./librarian.js";
+import { metisFactory } from "./metis.js";
+import { prometheusFactory } from "./prometheus.js";
 import type { DynamicPromptBuilder } from "../prompts/DynamicPromptBuilder.js";
 import type { AgentRegistry } from "../registry/AgentRegistry.js";
 
@@ -10,4 +14,8 @@ export function registerBuiltInAgents(registry: AgentRegistry, promptBuilder: Dy
 	registry.register("sisyphus-junior", sisyphusJuniorFactory, "multi-agent");
 	registry.register("oracle", oracleFactory, "multi-agent");
 	registry.register("explore", exploreFactory, "multi-agent");
+	registry.register("hephaestus", hephaestusFactory, "multi-agent");
+	registry.register("librarian", librarianFactory, "multi-agent");
+	registry.register("metis", metisFactory, "multi-agent");
+	registry.register("prometheus", prometheusFactory, "multi-agent");
 }

--- a/extensions/multi-agent/src/agents/librarian.ts
+++ b/extensions/multi-agent/src/agents/librarian.ts
@@ -1,0 +1,17 @@
+import type { AgentConfig, AgentFactory } from "../registry/types.js";
+
+export const librarianFactory: AgentFactory = Object.assign(
+	(model: string): AgentConfig => ({
+		name: "librarian",
+		description: "Research and reference retrieval specialist.",
+		whenToUse: "Use for documentation lookup, dependency research, and source-backed recommendations.",
+		systemPrompt: [
+			"You are Librarian, a documentation and research specialist.",
+			"Prioritize source-backed findings and concise citations from available materials.",
+			`Active model: ${model}`,
+		].join("\n"),
+		tools: ["read", "find", "grep", "ls"],
+		defaultThinkingLevel: "medium",
+	}),
+	{ mode: "subagent" as const },
+);

--- a/extensions/multi-agent/src/agents/metis.ts
+++ b/extensions/multi-agent/src/agents/metis.ts
@@ -1,0 +1,17 @@
+import type { AgentConfig, AgentFactory } from "../registry/types.js";
+
+export const metisFactory: AgentFactory = Object.assign(
+	(model: string): AgentConfig => ({
+		name: "metis",
+		description: "Planning consultant for decomposing work into executable slices.",
+		whenToUse: "Use for risk analysis, sequencing, and implementation planning.",
+		systemPrompt: [
+			"You are Metis, a planning and strategy assistant for engineering execution.",
+			"Produce concrete phased plans with explicit risks, assumptions, and verification gates.",
+			`Active model: ${model}`,
+		].join("\n"),
+		tools: ["read", "find", "grep", "ls"],
+		defaultThinkingLevel: "high",
+	}),
+	{ mode: "subagent" as const },
+);

--- a/extensions/multi-agent/src/agents/prometheus.ts
+++ b/extensions/multi-agent/src/agents/prometheus.ts
@@ -1,0 +1,17 @@
+import type { AgentConfig, AgentFactory } from "../registry/types.js";
+
+export const prometheusFactory: AgentFactory = Object.assign(
+	(model: string): AgentConfig => ({
+		name: "prometheus",
+		description: "High-level orchestration strategist focused on long-horizon planning.",
+		whenToUse: "Use for strategy, system-level tradeoffs, and acceptance criteria refinement.",
+		systemPrompt: [
+			"You are Prometheus, a strategic orchestrator for complex software delivery.",
+			"Focus on long-horizon decision quality, constraints, and measurable outcomes.",
+			`Active model: ${model}`,
+		].join("\n"),
+		tools: ["read", "find", "grep", "ls", "task", "background_output"],
+		defaultThinkingLevel: "high",
+	}),
+	{ mode: "subagent" as const },
+);

--- a/extensions/multi-agent/src/index.ts
+++ b/extensions/multi-agent/src/index.ts
@@ -1,5 +1,11 @@
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import {
+	createIpcMessage,
+	type PubSubSubscribeMessage,
+	type SessionFollowUpMessage,
+	type SessionSteerMessage,
+} from "@mariozechner/pi-ipc";
 import { registerBuiltInAgents } from "./agents/index.js";
 import { loadMultiAgentConfig } from "./config.js";
 import { TaskDelegator } from "./orchestration/TaskDelegator.js";
@@ -67,6 +73,21 @@ function splitArgs(raw: string): string[] {
 		.filter((value) => value.length > 0);
 }
 
+function splitFirstArg(raw: string): { first: string | undefined; rest: string } {
+	const trimmed = raw.trim();
+	if (trimmed.length === 0) {
+		return { first: undefined, rest: "" };
+	}
+	const firstSpace = trimmed.indexOf(" ");
+	if (firstSpace === -1) {
+		return { first: trimmed, rest: "" };
+	}
+	return {
+		first: trimmed.slice(0, firstSpace),
+		rest: trimmed.slice(firstSpace + 1).trim(),
+	};
+}
+
 function renderAgentList(ctx: ExtensionCommandContext): string {
 	const current = buildRuntime(ctx);
 	return current.registry
@@ -103,6 +124,51 @@ async function renderResolvedAgent(ctx: ExtensionCommandContext, agentName: stri
 	return `${agentName} -> ${resolved.modelId} via ${resolved.resolvedVia}${thinking}`;
 }
 
+async function renderAllResolvedAgents(ctx: ExtensionCommandContext): Promise<string> {
+	const current = buildRuntime(ctx);
+	const lines = await Promise.all(
+		current.registry.list().map(async (agentName) => {
+			try {
+				return await renderResolvedAgent(ctx, agentName);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return `${agentName} -> unresolved (${message})`;
+			}
+		}),
+	);
+	return lines.join("\n");
+}
+
+function resolveTargetSocket(ctx: ExtensionCommandContext, sessionId: string): string {
+	if (!ctx.agentDiscovery) {
+		throw new Error("agentDiscovery is unavailable in this runtime.");
+	}
+	const socketPath = ctx.agentDiscovery.getSocketPath(sessionId);
+	if (!socketPath) {
+		throw new Error(`No alive agent session found for ${sessionId}.`);
+	}
+	return socketPath;
+}
+
+async function sendIpcCommand(
+	ctx: ExtensionCommandContext,
+	socketPath: string,
+	message: SessionSteerMessage | SessionFollowUpMessage | PubSubSubscribeMessage,
+): Promise<void> {
+	if (!ctx.createIpcClient) {
+		throw new Error("createIpcClient() is unavailable in this runtime.");
+	}
+	const client = ctx.createIpcClient(socketPath);
+	try {
+		const response = await client.send(message);
+		if (!response.success) {
+			throw new Error(response.error ?? "ipc_request_failed");
+		}
+	} finally {
+		await client.disconnect();
+	}
+}
+
 export default function multiAgentExtension(pi: ExtensionAPI): void {
 	pi.on("session_start", (_event, ctx) => {
 		buildRuntime(ctx);
@@ -132,6 +198,13 @@ export default function multiAgentExtension(pi: ExtensionAPI): void {
 				throw new Error("Usage: /agent.get_model <agentName> [category]");
 			}
 			console.log(await renderResolvedAgent(ctx, agentName, category));
+		},
+	});
+
+	pi.registerCommand("agent.list_models", {
+		description: "Resolve effective model assignments for all registered agents",
+		handler: async (_args, ctx) => {
+			console.log(await renderAllResolvedAgents(ctx));
 		},
 	});
 
@@ -179,6 +252,139 @@ export default function multiAgentExtension(pi: ExtensionAPI): void {
 		handler: async (args, ctx) => {
 			const [provider] = splitArgs(args);
 			console.log(renderModelList(ctx, provider));
+		},
+	});
+
+	pi.registerCommand("agent.list_available_models", {
+		description: "List available models, optionally filtered by provider",
+		handler: async (args, ctx) => {
+			const [provider] = splitArgs(args);
+			console.log(renderModelList(ctx, provider));
+		},
+	});
+
+	pi.registerCommand("agent.discover", {
+		description: "List alive IPC agent sessions discovered from socket metadata",
+		handler: async (_args, ctx) => {
+			if (!ctx.agentDiscovery) {
+				throw new Error("agentDiscovery is unavailable in this runtime.");
+			}
+			const records = ctx.agentDiscovery.listAlive();
+			if (records.length === 0) {
+				console.log("No alive agent sessions discovered.");
+				return;
+			}
+			console.log(
+				records
+					.map(
+						(record) =>
+							`${record.sessionId} socket=${record.socketPath} agent=${record.agentName ?? "unknown"} status=${record.status ?? "unknown"}`,
+					)
+					.join("\n"),
+			);
+		},
+	});
+
+	pi.registerCommand("session.mesh.status", {
+		description: "Show local mesh connectivity summary",
+		handler: async (_args, ctx) => {
+			if (!ctx.agentDiscovery) {
+				console.log("mesh=disabled (agentDiscovery unavailable)");
+				return;
+			}
+			const records = ctx.agentDiscovery.listAlive();
+			const withAgentName = records.filter((record) => record.agentName !== undefined).length;
+			console.log(
+				[
+					`alive_sessions=${records.length}`,
+					`named_agents=${withAgentName}`,
+					`ipc_client_factory=${ctx.createIpcClient ? "available" : "unavailable"}`,
+				].join(" "),
+			);
+		},
+	});
+
+	pi.registerCommand("agent.send", {
+		description: "Send follow-up message to another alive session",
+		handler: async (args, ctx) => {
+			const { first: sessionId, rest: message } = splitFirstArg(args);
+			if (!sessionId || !message) {
+				throw new Error("Usage: /agent.send <targetSessionId> <message>");
+			}
+			const socketPath = resolveTargetSocket(ctx, sessionId);
+			await sendIpcCommand(
+				ctx,
+				socketPath,
+				createIpcMessage<SessionFollowUpMessage>({
+					type: "session.follow_up",
+					payload: {
+						targetSessionId: sessionId,
+						message,
+						token: "local",
+					},
+					senderSessionId: ctx.sessionManager.getSessionId(),
+				}),
+			);
+			console.log(`sent follow-up to ${sessionId}`);
+		},
+	});
+
+	pi.registerCommand("agent.steer", {
+		description: "Send steering message to another alive session",
+		handler: async (args, ctx) => {
+			const { first: sessionId, rest: message } = splitFirstArg(args);
+			if (!sessionId || !message) {
+				throw new Error("Usage: /agent.steer <targetSessionId> <message>");
+			}
+			const socketPath = resolveTargetSocket(ctx, sessionId);
+			await sendIpcCommand(
+				ctx,
+				socketPath,
+				createIpcMessage<SessionSteerMessage>({
+					type: "session.steer",
+					payload: {
+						targetSessionId: sessionId,
+						message,
+						token: "local",
+					},
+					senderSessionId: ctx.sessionManager.getSessionId(),
+				}),
+			);
+			console.log(`sent steer message to ${sessionId}`);
+		},
+	});
+
+	pi.registerCommand("agent.subscribe", {
+		description: "Send pub/sub subscription request to target session",
+		handler: async (args, ctx) => {
+			const [sessionId, topicsRaw] = splitArgs(args);
+			if (!sessionId || !topicsRaw) {
+				throw new Error("Usage: /agent.subscribe <targetSessionId> <topic[,topic2,...]>");
+			}
+			const topics = topicsRaw
+				.split(",")
+				.map((topic) => topic.trim())
+				.filter((topic) => topic.length > 0);
+			if (topics.length === 0) {
+				throw new Error("At least one topic is required.");
+			}
+
+			const socketPath = resolveTargetSocket(ctx, sessionId);
+			const callbackSocketPath = resolveTargetSocket(ctx, ctx.sessionManager.getSessionId());
+			await sendIpcCommand(
+				ctx,
+				socketPath,
+				createIpcMessage<PubSubSubscribeMessage>({
+					type: "pubsub.subscribe",
+					payload: {
+						topics,
+						subscriberSessionId: ctx.sessionManager.getSessionId(),
+						callbackSocketPath,
+					},
+					senderSessionId: ctx.sessionManager.getSessionId(),
+				}),
+			);
+			console.log(`subscription request sent to ${sessionId} for topics: ${topics.join(", ")}`);
 		},
 	});
 }

--- a/extensions/multi-agent/src/orchestration/TaskDelegator.ts
+++ b/extensions/multi-agent/src/orchestration/TaskDelegator.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { createIpcMessage, type TaskDelegateMessage } from "@mariozechner/pi-ipc";
 import type { AgentRegistry } from "../registry/AgentRegistry.js";
 import type { CategoryRouter } from "../routing/CategoryRouter.js";
 import { ModelRouter } from "../routing/ModelRouter.js";
@@ -26,6 +27,10 @@ interface ExecutionStrategy {
 	agentName: string;
 	category?: string;
 	resolved: ResolvedModel;
+	remote?: {
+		sessionId: string;
+		socketPath: string;
+	};
 }
 
 interface BackgroundTaskHandle {
@@ -97,7 +102,7 @@ export class TaskDelegator {
 	}
 
 	async execute(params: TaskDelegateParams, ctx: ExtensionContext): Promise<TaskDelegateResult> {
-		const strategy = await this.resolveStrategy(params);
+		const strategy = await this.resolveStrategy(params, ctx);
 		if (params.run_in_background) {
 			return this.executeBackground(params, strategy, ctx);
 		}
@@ -127,7 +132,7 @@ export class TaskDelegator {
 		return true;
 	}
 
-	private async resolveStrategy(params: TaskDelegateParams): Promise<ExecutionStrategy> {
+	private async resolveStrategy(params: TaskDelegateParams, ctx: ExtensionContext): Promise<ExecutionStrategy> {
 		if (params.agent) {
 			const factory = this.registry.get(params.agent);
 			if (!factory) {
@@ -137,10 +142,12 @@ export class TaskDelegator {
 				throw new Error(`Agent ${params.agent} cannot be called via task(); mode=${factory.mode}`);
 			}
 			const resolved = await this.modelRouter.resolveForAgent(params.agent, params.category);
+			const remote = this.resolveRemoteTarget(params.agent, ctx);
 			return {
 				type: "agent",
 				agentName: params.agent,
 				resolved,
+				remote,
 			};
 		}
 
@@ -171,6 +178,10 @@ export class TaskDelegator {
 		strategy: ExecutionStrategy,
 		ctx: ExtensionContext,
 	): Promise<TaskDelegateResult> {
+		if (strategy.remote && ctx.createIpcClient) {
+			return this.executeRemoteSync(params, strategy, ctx);
+		}
+
 		if (!ctx.runSubAgent) {
 			throw new Error("This runtime does not support runSubAgent(). Update to a compatible pi-coding-agent build.");
 		}
@@ -206,6 +217,67 @@ export class TaskDelegator {
 				resolved_via: strategy.resolved.resolvedVia,
 			},
 		};
+	}
+
+	private async executeRemoteSync(
+		params: TaskDelegateParams,
+		strategy: ExecutionStrategy,
+		ctx: ExtensionContext,
+	): Promise<TaskDelegateResult> {
+		if (!strategy.remote || !ctx.createIpcClient) {
+			throw new Error("Remote delegation requires IPC client support.");
+		}
+
+		const sessionId = params.session_id ?? `ses_${randomUUID()}`;
+		const startedAt = new Date().toISOString();
+		const prompt = this.applySkillPrelude(params.prompt, params.load_skills);
+		const taskId = `task_${randomUUID()}`;
+		const client = ctx.createIpcClient(strategy.remote.socketPath);
+
+		try {
+			const response = await client.send(
+				createIpcMessage<TaskDelegateMessage>({
+					type: "task.delegate",
+					payload: {
+						taskId,
+						sessionId,
+						parentSessionId: ctx.sessionManager.getSessionId(),
+						prompt,
+						agentName: strategy.agentName,
+						category: strategy.category,
+						model: strategy.resolved.modelId,
+						skills: params.load_skills,
+					},
+					senderSessionId: ctx.sessionManager.getSessionId(),
+				}),
+			);
+
+			if (!response.success) {
+				throw new Error(response.error ?? "remote_task_delegate_failed");
+			}
+
+			const data = response.data as
+				| {
+						output?: string;
+						tokenUsage?: { input: number; output: number };
+				  }
+				| undefined;
+			return {
+				session_id: sessionId,
+				mode: "sync",
+				output: data?.output ?? "",
+				model_used: strategy.resolved.modelId,
+				agent_used: strategy.agentName,
+				metadata: {
+					started_at: startedAt,
+					completed_at: new Date().toISOString(),
+					token_usage: data?.tokenUsage,
+					resolved_via: `${strategy.resolved.resolvedVia}:remote`,
+				},
+			};
+		} finally {
+			await client.disconnect();
+		}
 	}
 
 	private async executeBackground(
@@ -256,5 +328,24 @@ export class TaskDelegator {
 			return prompt;
 		}
 		return [`Requested skills: ${skills.join(", ")}`, "", prompt].join("\n");
+	}
+
+	private resolveRemoteTarget(agentName: string, ctx: ExtensionContext): ExecutionStrategy["remote"] | undefined {
+		if (!ctx.agentDiscovery || !ctx.createIpcClient) {
+			return undefined;
+		}
+
+		const currentSessionId = ctx.sessionManager.getSessionId();
+		const target = ctx.agentDiscovery
+			.listAlive()
+			.find((record) => record.agentName === agentName && record.sessionId !== currentSessionId);
+		if (!target) {
+			return undefined;
+		}
+
+		return {
+			sessionId: target.sessionId,
+			socketPath: target.socketPath,
+		};
 	}
 }

--- a/extensions/multi-agent/test/task-delegator.test.ts
+++ b/extensions/multi-agent/test/task-delegator.test.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { AgentDiscoveryRecord, IpcResponse, TaskDelegateMessage } from "@mariozechner/pi-ipc";
 import { describe, expect, test } from "vitest";
 import { registerBuiltInAgents } from "../src/agents/index.js";
 import { TaskDelegator } from "../src/orchestration/TaskDelegator.js";
@@ -7,7 +8,25 @@ import { AgentRegistry } from "../src/registry/AgentRegistry.js";
 import { CategoryRouter } from "../src/routing/CategoryRouter.js";
 import type { MultiAgentConfig } from "../src/routing/types.js";
 
-function createContext(): ExtensionContext {
+interface CreateContextOptions {
+	remote?: {
+		sessionId: string;
+		socketPath: string;
+		output?: string;
+	};
+}
+
+function createContext(options: CreateContextOptions = {}): ExtensionContext {
+	const remoteRecord: AgentDiscoveryRecord | undefined = options.remote
+		? {
+				sessionId: options.remote.sessionId,
+				socketPath: options.remote.socketPath,
+				agentName: "oracle",
+				status: "idle",
+				updatedAt: new Date().toISOString(),
+			}
+		: undefined;
+
 	return {
 		ui: {
 			select: async () => undefined,
@@ -89,6 +108,37 @@ function createContext(): ExtensionContext {
 		getContextUsage: () => undefined,
 		compact: () => {},
 		getSystemPrompt: () => "",
+		agentDiscovery: remoteRecord
+			? (({
+					socketDir: "",
+					listAlive: () => [remoteRecord],
+					findBySessionId: (sessionId: string) =>
+						sessionId === remoteRecord.sessionId ? remoteRecord : undefined,
+					getSocketPath: (sessionId: string) =>
+						sessionId === remoteRecord.sessionId ? remoteRecord.socketPath : undefined,
+				}) as unknown as ExtensionContext["agentDiscovery"])
+			: undefined,
+		createIpcClient: remoteRecord
+			? ((() => {
+					return {
+						send: async (message: TaskDelegateMessage): Promise<IpcResponse> => {
+							expect(message.type).toBe("task.delegate");
+							return {
+								id: message.id,
+								type: "response",
+								timestamp: new Date().toISOString(),
+								success: true,
+								data: {
+									sessionId: message.payload.sessionId,
+									output: options.remote?.output ?? "remote-output",
+									tokenUsage: { input: 5, output: 7 },
+								},
+							};
+						},
+						disconnect: async () => {},
+					};
+				}) as unknown as ExtensionContext["createIpcClient"])
+			: undefined,
 		runSubAgent: async (options) => ({
 			sessionId: options.sessionId ?? "ses_sub",
 			finalText: `subagent:${options.agentName}:${options.prompt}`,
@@ -147,5 +197,30 @@ describe("TaskDelegator", () => {
 		expect(result.mode).toBe("background");
 		expect(result.task_id).toBeTruthy();
 		expect(["running", "completed"]).toContain(delegator.getBackgroundTask(result.task_id as string)?.status);
+	});
+
+	test("delegates to remote discovered agent over IPC when available", async () => {
+		const ctx = createContext({
+			remote: {
+				sessionId: "ses_remote",
+				socketPath: "/tmp/ses_remote.sock",
+				output: "remote-result",
+			},
+		});
+		const registry = new AgentRegistry();
+		const categoryRouter = new CategoryRouter();
+		registerBuiltInAgents(registry, new DynamicPromptBuilder(registry, categoryRouter));
+		const delegator = new TaskDelegator(registry, categoryRouter, {}, ctx);
+
+		const result = await delegator.execute(
+			{
+				prompt: "Cross-session request",
+				agent: "oracle",
+			},
+			ctx,
+		);
+
+		expect(result.output).toBe("remote-result");
+		expect(result.metadata.resolved_via).toContain(":remote");
 	});
 });

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -16,6 +16,7 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
+import { inspect } from "node:util";
 import type {
 	Agent,
 	AgentEvent,
@@ -203,6 +204,11 @@ export interface PromptOptions {
 	streamingBehavior?: "steer" | "followUp";
 	/** Source of input for extension input event handlers. Defaults to "interactive". */
 	source?: InputSource;
+}
+
+export interface ExecuteExtensionCommandOptions {
+	captureOutput?: boolean;
+	suppressErrors?: boolean;
 }
 
 /** Result from cycleModel() */
@@ -1264,31 +1270,87 @@ export class AgentSession {
 	 * Try to execute an extension command. Returns true if command was found and executed.
 	 */
 	private async _tryExecuteExtensionCommand(text: string): Promise<boolean> {
-		if (!this._extensionRunner) return false;
+		const parsed = this._parseSlashCommand(text);
+		if (!parsed) {
+			return false;
+		}
+		const result = await this.executeExtensionCommand(parsed.commandName, parsed.args, {
+			captureOutput: false,
+			suppressErrors: true,
+		});
+		return result.handled;
+	}
 
-		// Parse command name and args
-		const spaceIndex = text.indexOf(" ");
-		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1);
+	async executeExtensionCommand(
+		commandName: string,
+		args = "",
+		options: ExecuteExtensionCommandOptions = {},
+	): Promise<{ handled: boolean; output: string[] }> {
+		if (!this._extensionRunner) {
+			return { handled: false, output: [] };
+		}
 
 		const command = this._extensionRunner.getCommand(commandName);
-		if (!command) return false;
+		if (!command) {
+			return { handled: false, output: [] };
+		}
 
-		// Get command context from extension runner (includes session control methods)
 		const ctx = this._extensionRunner.createCommandContext();
+		const output: string[] = [];
+		const captureOutput = options.captureOutput ?? false;
+		const suppressErrors = options.suppressErrors ?? false;
+		const originalConsoleLog = console.log;
+
+		if (captureOutput) {
+			console.log = (...values: unknown[]) => {
+				output.push(this._formatConsoleLogValues(values));
+			};
+		}
 
 		try {
 			await command.handler(args, ctx);
-			return true;
-		} catch (err) {
-			// Emit error via extension runner
+			return { handled: true, output };
+		} catch (error) {
 			this._extensionRunner.emitError({
 				extensionPath: `command:${commandName}`,
 				event: "command",
-				error: err instanceof Error ? err.message : String(err),
+				error: error instanceof Error ? error.message : String(error),
 			});
-			return true;
+			if (suppressErrors) {
+				return { handled: true, output };
+			}
+			throw error;
+		} finally {
+			if (captureOutput) {
+				console.log = originalConsoleLog;
+			}
 		}
+	}
+
+	private _formatConsoleLogValues(values: unknown[]): string {
+		return values
+			.map((value) =>
+				typeof value === "string"
+					? value
+					: inspect(value, {
+							colors: false,
+							depth: 6,
+							maxArrayLength: 200,
+							maxStringLength: 20_000,
+						}),
+			)
+			.join(" ");
+	}
+
+	private _parseSlashCommand(text: string): { commandName: string; args: string } | null {
+		const trimmed = text.trim();
+		if (!trimmed.startsWith("/")) {
+			return null;
+		}
+		const spaceIndex = trimmed.indexOf(" ");
+		const commandName = spaceIndex === -1 ? trimmed.slice(1) : trimmed.slice(1, spaceIndex);
+		const args = spaceIndex === -1 ? "" : trimmed.slice(spaceIndex + 1);
+		return { commandName, args };
 	}
 
 	/**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -27,7 +27,16 @@ import type {
 import { Agent as CoreAgent } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, ImageContent, Message, Model, TextContent } from "@mariozechner/pi-ai";
 import { isContextOverflow, modelsAreEqual, resetApiProviders, supportsXhigh } from "@mariozechner/pi-ai";
-import type { IpcMessage, IpcResponse, TaskProgressMessage, TaskResultMessage } from "@mariozechner/pi-ipc";
+import type {
+	AgentDiscoveryRecord,
+	IpcMessage,
+	IpcResponse,
+	PubSubSubscribeMessage,
+	SessionFollowUpMessage,
+	SessionSteerMessage,
+	TaskProgressMessage,
+	TaskResultMessage,
+} from "@mariozechner/pi-ipc";
 import {
 	AgentDiscovery,
 	AgentIpcClient,
@@ -932,6 +941,90 @@ export class AgentSession {
 	/** IPC socket path for this session (when IPC is enabled). */
 	get ipcSocketPath(): string | undefined {
 		return this._ipcServer?.socketPath;
+	}
+
+	getDiscoveredAgents(): AgentDiscoveryRecord[] {
+		return this._agentDiscovery?.listAlive() ?? [];
+	}
+
+	getMeshStatus(): {
+		enabled: boolean;
+		running: boolean;
+		sessionId: string;
+		socketPath?: string;
+		aliveAgents: number;
+	} {
+		return {
+			enabled: this._enableIpc,
+			running: this._ipcServer?.isRunning() ?? false,
+			sessionId: this.sessionId,
+			socketPath: this.ipcSocketPath,
+			aliveAgents: this.getDiscoveredAgents().length,
+		};
+	}
+
+	async sendMeshFollowUp(targetSessionId: string, message: string): Promise<IpcResponse> {
+		return this._sendMeshMessage(
+			targetSessionId,
+			createIpcMessage<SessionFollowUpMessage>({
+				type: "session.follow_up",
+				payload: {
+					targetSessionId,
+					message,
+					token: "local",
+				},
+				senderSessionId: this.sessionId,
+			}),
+		);
+	}
+
+	async sendMeshSteer(targetSessionId: string, message: string): Promise<IpcResponse> {
+		return this._sendMeshMessage(
+			targetSessionId,
+			createIpcMessage<SessionSteerMessage>({
+				type: "session.steer",
+				payload: {
+					targetSessionId,
+					message,
+					token: "local",
+				},
+				senderSessionId: this.sessionId,
+			}),
+		);
+	}
+
+	async sendMeshSubscribe(targetSessionId: string, topics: string[]): Promise<IpcResponse> {
+		const callbackSocketPath = this.ipcSocketPath ?? this._resolveMeshSocketPath(this.sessionId);
+		return this._sendMeshMessage(
+			targetSessionId,
+			createIpcMessage<PubSubSubscribeMessage>({
+				type: "pubsub.subscribe",
+				payload: {
+					topics,
+					subscriberSessionId: this.sessionId,
+					callbackSocketPath,
+				},
+				senderSessionId: this.sessionId,
+			}),
+		);
+	}
+
+	private _resolveMeshSocketPath(sessionId: string): string {
+		const socketPath = this._agentDiscovery?.getSocketPath(sessionId);
+		if (!socketPath) {
+			throw new Error(`No alive session discovered for ${sessionId}.`);
+		}
+		return socketPath;
+	}
+
+	private async _sendMeshMessage(targetSessionId: string, message: IpcMessage): Promise<IpcResponse> {
+		const socketPath = this._resolveMeshSocketPath(targetSessionId);
+		const client = new AgentIpcClient({ socketPath });
+		try {
+			return await client.send(message);
+		} finally {
+			await client.disconnect();
+		}
 	}
 
 	/** Current session display name, if set */

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -27,7 +27,7 @@ import type {
 import { Agent as CoreAgent } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, ImageContent, Message, Model, TextContent } from "@mariozechner/pi-ai";
 import { isContextOverflow, modelsAreEqual, resetApiProviders, supportsXhigh } from "@mariozechner/pi-ai";
-import type { IpcMessage, IpcResponse, TaskProgressMessage } from "@mariozechner/pi-ipc";
+import type { IpcMessage, IpcResponse, TaskProgressMessage, TaskResultMessage } from "@mariozechner/pi-ipc";
 import {
 	AgentDiscovery,
 	AgentIpcClient,
@@ -173,6 +173,8 @@ export interface AgentSessionConfig {
 	onIpcServerStop?: () => void;
 	/** Optional externally-provided agent registry surfaced to extensions */
 	agentRegistry?: AgentRegistryAdapter;
+	/** Optional explicit agent name advertised over IPC discovery metadata */
+	agentName?: string;
 }
 
 export interface ExtensionBindings {
@@ -291,6 +293,7 @@ export class AgentSession {
 	// Model registry for API key resolution
 	private _modelRegistry: ModelRegistry;
 	private _agentRegistry?: AgentRegistryAdapter;
+	private _agentName?: string;
 
 	// IPC integration
 	private _enableIpc = false;
@@ -319,6 +322,7 @@ export class AgentSession {
 		this._cwd = config.cwd;
 		this._modelRegistry = config.modelRegistry;
 		this._agentRegistry = config.agentRegistry;
+		this._agentName = config.agentName;
 		this._extensionRunnerRef = config.extensionRunnerRef;
 		this._initialActiveToolNames = config.initialActiveToolNames;
 		this._baseToolsOverride = config.baseToolsOverride;
@@ -650,6 +654,9 @@ export class AgentSession {
 			sessionId: this.sessionId,
 			socketDir: this._ipcSocketDir,
 			onMessage: async (message) => this._routeIpcMessage(message),
+			agentName: this._agentName ?? this.sessionName ?? "agent",
+			status: "idle",
+			currentModel: this._currentModelRef(),
 		});
 		try {
 			await this._ipcServer.start();
@@ -690,6 +697,57 @@ export class AgentSession {
 					data: { queued: true, queue: "follow_up" },
 				});
 			}
+			case "task.delegate": {
+				const startedAt = Date.now();
+				const targetModel = message.payload.model ?? this._currentModelRef();
+				if (!targetModel) {
+					return createIpcResponse({
+						id: message.id,
+						success: false,
+						error: "task_delegate_requires_model",
+					});
+				}
+
+				const registeredAgent = this._resolveTaskDelegateAgentConfig(message.payload.agentName, targetModel);
+				const result = await this.runSubAgent({
+					agentName: message.payload.agentName ?? this._agentName ?? "sisyphus-junior",
+					sessionId: message.payload.sessionId,
+					taskId: message.payload.taskId,
+					systemPrompt: registeredAgent?.systemPrompt ?? this.systemPrompt,
+					model: targetModel,
+					tools: registeredAgent?.tools ?? this.getActiveToolNames(),
+					prompt: message.payload.prompt,
+					thinkingLevel: registeredAgent?.defaultThinkingLevel ?? this.thinkingLevel,
+					inheritMessages: false,
+					ipcForward: true,
+				});
+
+				this._ipcServer?.broadcast(
+					createIpcMessage<TaskResultMessage>({
+						type: "task.result",
+						payload: {
+							taskId: message.payload.taskId,
+							sessionId: result.sessionId,
+							success: true,
+							output: result.finalText,
+							tokenUsage: result.tokenUsage,
+							durationMs: Date.now() - startedAt,
+						},
+						senderSessionId: this.sessionId,
+					}),
+				);
+
+				return createIpcResponse({
+					id: message.id,
+					success: true,
+					data: {
+						taskId: message.payload.taskId,
+						sessionId: result.sessionId,
+						output: result.finalText,
+						tokenUsage: result.tokenUsage,
+					},
+				});
+			}
 			default: {
 				if (this._onIpcMessage) {
 					const response = await this._onIpcMessage(message);
@@ -715,6 +773,54 @@ export class AgentSession {
 			content: [{ type: "text", text }],
 			timestamp: Date.now(),
 		};
+	}
+
+	private _currentModelRef(): string | undefined {
+		return this.model ? `${this.model.provider}/${this.model.id}` : undefined;
+	}
+
+	private _resolveTaskDelegateAgentConfig(
+		agentName: string | undefined,
+		model: string,
+	):
+		| {
+				systemPrompt: string;
+				tools: string[];
+				defaultThinkingLevel?: ThinkingLevel;
+		  }
+		| undefined {
+		if (!agentName || !this._agentRegistry?.instantiate) {
+			return undefined;
+		}
+
+		try {
+			const candidate = this._agentRegistry.instantiate(agentName, model);
+			if (typeof candidate !== "object" || candidate === null) {
+				return undefined;
+			}
+
+			const record = candidate as Record<string, unknown>;
+			if (typeof record.systemPrompt !== "string" || !Array.isArray(record.tools)) {
+				return undefined;
+			}
+			const tools = record.tools.filter((tool): tool is string => typeof tool === "string");
+			if (tools.length === 0) {
+				return undefined;
+			}
+
+			const defaultThinkingLevel =
+				typeof record.defaultThinkingLevel === "string" &&
+				THINKING_LEVELS_WITH_XHIGH.includes(record.defaultThinkingLevel as ThinkingLevel)
+					? (record.defaultThinkingLevel as ThinkingLevel)
+					: undefined;
+			return {
+				systemPrompt: record.systemPrompt,
+				tools,
+				defaultThinkingLevel,
+			};
+		} catch {
+			return undefined;
+		}
 	}
 
 	// =========================================================================
@@ -1438,6 +1544,7 @@ export class AgentSession {
 
 		// Re-clamp thinking level for new model's capabilities
 		this.setThinkingLevel(this.thinkingLevel);
+		this._ipcServer?.updateMetadata({ currentModel: this._currentModelRef() });
 
 		await this._emitModelSelect(model, previousModel, "set");
 	}
@@ -1496,6 +1603,7 @@ export class AgentSession {
 
 		// Apply thinking level (setThinkingLevel clamps to model capabilities)
 		this.setThinkingLevel(next.thinkingLevel);
+		this._ipcServer?.updateMetadata({ currentModel: this._currentModelRef() });
 
 		await this._emitModelSelect(next.model, currentModel, "cycle");
 
@@ -1525,6 +1633,7 @@ export class AgentSession {
 
 		// Re-clamp thinking level for new model's capabilities
 		this.setThinkingLevel(this.thinkingLevel);
+		this._ipcServer?.updateMetadata({ currentModel: this._currentModelRef() });
 
 		await this._emitModelSelect(nextModel, currentModel, "cycle");
 
@@ -2623,6 +2732,7 @@ export class AgentSession {
 			);
 			if (match) {
 				this.agent.setModel(match);
+				this._ipcServer?.updateMetadata({ currentModel: this._currentModelRef() });
 				await this._emitModelSelect(match, previousModel, "restore");
 			}
 		}

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -12,7 +12,7 @@ import type { AgentDiscoveryRecord, IpcResponse } from "@mariozechner/pi-ipc";
 import type { SessionStats } from "../../core/agent-session.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
-import type { RpcCommand, RpcResponse, RpcSessionState, RpcSlashCommand } from "./rpc-types.js";
+import type { RpcCommand, RpcResolvedAgentModel, RpcResponse, RpcSessionState, RpcSlashCommand } from "./rpc-types.js";
 
 // ============================================================================
 // Types
@@ -415,6 +415,44 @@ export class RpcClient {
 	}> {
 		const response = await this.send({ type: "session.mesh.status" });
 		return this.getData(response);
+	}
+
+	async listAgentModels(): Promise<RpcResolvedAgentModel[]> {
+		const response = await this.send({ type: "agent.list_models" });
+		return this.getData<{ agents: RpcResolvedAgentModel[] }>(response).agents;
+	}
+
+	async getAgentModel(agentName: string, category?: string): Promise<RpcResolvedAgentModel> {
+		const response = await this.send({ type: "agent.get_model", agentName, category });
+		return this.getData<{ resolved: RpcResolvedAgentModel }>(response).resolved;
+	}
+
+	async setAgentModel(
+		agentName: string,
+		model: string,
+		thinkingLevel?: ThinkingLevel,
+	): Promise<RpcResolvedAgentModel> {
+		const response = await this.send({ type: "agent.set_model", agentName, model, thinkingLevel });
+		return this.getData<{ resolved: RpcResolvedAgentModel }>(response).resolved;
+	}
+
+	async setAgentProvider(
+		agentName: string,
+		provider: string,
+		thinkingLevel?: ThinkingLevel,
+	): Promise<RpcResolvedAgentModel> {
+		const response = await this.send({ type: "agent.set_provider", agentName, provider, thinkingLevel });
+		return this.getData<{ resolved: RpcResolvedAgentModel }>(response).resolved;
+	}
+
+	async resetAgentModel(agentName: string): Promise<RpcResolvedAgentModel> {
+		const response = await this.send({ type: "agent.reset_model", agentName });
+		return this.getData<{ resolved: RpcResolvedAgentModel }>(response).resolved;
+	}
+
+	async listAgentAvailableModels(provider?: string): Promise<Array<{ provider: string; modelId: string }>> {
+		const response = await this.send({ type: "agent.list_available_models", provider });
+		return this.getData<{ models: Array<{ provider: string; modelId: string }> }>(response).models;
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -8,6 +8,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import * as readline from "node:readline";
 import type { AgentEvent, AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
+import type { AgentDiscoveryRecord, IpcResponse } from "@mariozechner/pi-ipc";
 import type { SessionStats } from "../../core/agent-session.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
@@ -383,6 +384,37 @@ export class RpcClient {
 	async getCommands(): Promise<RpcSlashCommand[]> {
 		const response = await this.send({ type: "get_commands" });
 		return this.getData<{ commands: RpcSlashCommand[] }>(response).commands;
+	}
+
+	async discoverAgents(): Promise<AgentDiscoveryRecord[]> {
+		const response = await this.send({ type: "agent.discover" });
+		return this.getData<{ agents: AgentDiscoveryRecord[] }>(response).agents;
+	}
+
+	async sendAgentMessage(targetSessionId: string, message: string): Promise<IpcResponse> {
+		const response = await this.send({ type: "agent.send", targetSessionId, message });
+		return this.getData<{ response: IpcResponse }>(response).response;
+	}
+
+	async steerAgent(targetSessionId: string, message: string): Promise<IpcResponse> {
+		const response = await this.send({ type: "agent.steer", targetSessionId, message });
+		return this.getData<{ response: IpcResponse }>(response).response;
+	}
+
+	async subscribeAgent(targetSessionId: string, topics: string[]): Promise<IpcResponse> {
+		const response = await this.send({ type: "agent.subscribe", targetSessionId, topics });
+		return this.getData<{ response: IpcResponse }>(response).response;
+	}
+
+	async getMeshStatus(): Promise<{
+		enabled: boolean;
+		running: boolean;
+		sessionId: string;
+		socketPath?: string;
+		aliveAgents: number;
+	}> {
+		const response = await this.send({ type: "session.mesh.status" });
+		return this.getData(response);
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -24,6 +24,7 @@ import type {
 	RpcCommand,
 	RpcExtensionUIRequest,
 	RpcExtensionUIResponse,
+	RpcResolvedAgentModel,
 	RpcResponse,
 	RpcSessionState,
 	RpcSlashCommand,
@@ -34,9 +35,72 @@ export type {
 	RpcCommand,
 	RpcExtensionUIRequest,
 	RpcExtensionUIResponse,
+	RpcResolvedAgentModel,
 	RpcResponse,
 	RpcSessionState,
 } from "./rpc-types.js";
+
+const RESOLVED_AGENT_MODEL_PATTERN = /^([^\s]+)\s*->\s*([^\s]+)\s+via\s+([^\s]+)(?:\s+thinking=([^\s]+))?$/;
+const UNRESOLVED_AGENT_MODEL_PATTERN = /^([^\s]+)\s*->\s*unresolved\s+\((.+)\)$/;
+
+function parseModelRef(modelRef: string): { provider?: string; modelId: string } {
+	const separatorIndex = modelRef.indexOf("/");
+	if (separatorIndex === -1) {
+		return { modelId: modelRef };
+	}
+	return {
+		provider: modelRef.slice(0, separatorIndex),
+		modelId: modelRef.slice(separatorIndex + 1),
+	};
+}
+
+export function parseResolvedAgentModelLine(line: string): RpcResolvedAgentModel | null {
+	const trimmed = line.trim();
+	if (trimmed.length === 0) {
+		return null;
+	}
+
+	const unresolvedMatch = trimmed.match(UNRESOLVED_AGENT_MODEL_PATTERN);
+	if (unresolvedMatch) {
+		return {
+			agentName: unresolvedMatch[1],
+			error: unresolvedMatch[2],
+		};
+	}
+
+	const resolvedMatch = trimmed.match(RESOLVED_AGENT_MODEL_PATTERN);
+	if (!resolvedMatch) {
+		return null;
+	}
+
+	const parsedModel = parseModelRef(resolvedMatch[2]);
+	return {
+		agentName: resolvedMatch[1],
+		modelId: resolvedMatch[2],
+		provider: parsedModel.provider,
+		resolvedVia: resolvedMatch[3],
+		thinkingLevel: resolvedMatch[4] as RpcResolvedAgentModel["thinkingLevel"] | undefined,
+	};
+}
+
+export function parseAvailableModelLines(lines: string[]): Array<{ provider: string; modelId: string }> {
+	const models: Array<{ provider: string; modelId: string }> = [];
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (trimmed.length === 0 || trimmed.startsWith("No models available")) {
+			continue;
+		}
+		const parsed = parseModelRef(trimmed);
+		if (!parsed.provider) {
+			continue;
+		}
+		models.push({
+			provider: parsed.provider,
+			modelId: parsed.modelId,
+		});
+	}
+	return models;
+}
 
 /**
  * Run in RPC mode.
@@ -311,6 +375,17 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 			output({ type: "extension_error", extensionPath: err.extensionPath, event: err.event, error: err.error });
 		},
 	});
+
+	const executeExtensionCommand = async (commandName: string, args = ""): Promise<string[]> => {
+		const result = await session.executeExtensionCommand(commandName, args, {
+			captureOutput: true,
+			suppressErrors: false,
+		});
+		if (!result.handled) {
+			throw new Error(`Extension command "/${commandName}" is not registered`);
+		}
+		return result.output.map((line) => line.trim()).filter((line) => line.length > 0);
+	};
 
 	// Output all agent events as JSON
 	session.subscribe((event) => {
@@ -610,6 +685,64 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 
 			case "session.mesh.status": {
 				return success(id, "session.mesh.status", session.getMeshStatus());
+			}
+
+			// =================================================================
+			// Agent model routing controls
+			// =================================================================
+
+			case "agent.list_models": {
+				const lines = await executeExtensionCommand("agent.list_models");
+				const agents = lines
+					.map((line) => parseResolvedAgentModelLine(line))
+					.filter((resolved): resolved is RpcResolvedAgentModel => resolved !== null);
+				return success(id, "agent.list_models", { agents });
+			}
+
+			case "agent.get_model": {
+				const args = command.category ? `${command.agentName} ${command.category}` : command.agentName;
+				const lines = await executeExtensionCommand("agent.get_model", args);
+				const resolved = lines.map((line) => parseResolvedAgentModelLine(line)).find((entry) => entry !== null);
+				if (!resolved) {
+					return error(id, "agent.get_model", `Unexpected /agent.get_model output: ${lines.join(" | ")}`);
+				}
+				return success(id, "agent.get_model", { resolved });
+			}
+
+			case "agent.set_model": {
+				const args = [command.agentName, command.model, command.thinkingLevel].filter(Boolean).join(" ");
+				const lines = await executeExtensionCommand("agent.set_model", args);
+				const resolved = lines.map((line) => parseResolvedAgentModelLine(line)).find((entry) => entry !== null);
+				if (!resolved) {
+					return error(id, "agent.set_model", `Unexpected /agent.set_model output: ${lines.join(" | ")}`);
+				}
+				return success(id, "agent.set_model", { resolved });
+			}
+
+			case "agent.set_provider": {
+				const args = [command.agentName, command.provider, command.thinkingLevel].filter(Boolean).join(" ");
+				const lines = await executeExtensionCommand("agent.set_provider", args);
+				const resolved = lines.map((line) => parseResolvedAgentModelLine(line)).find((entry) => entry !== null);
+				if (!resolved) {
+					return error(id, "agent.set_provider", `Unexpected /agent.set_provider output: ${lines.join(" | ")}`);
+				}
+				return success(id, "agent.set_provider", { resolved });
+			}
+
+			case "agent.reset_model": {
+				const lines = await executeExtensionCommand("agent.reset_model", command.agentName);
+				const resolved = lines.map((line) => parseResolvedAgentModelLine(line)).find((entry) => entry !== null);
+				if (!resolved) {
+					return error(id, "agent.reset_model", `Unexpected /agent.reset_model output: ${lines.join(" | ")}`);
+				}
+				return success(id, "agent.reset_model", { resolved });
+			}
+
+			case "agent.list_available_models": {
+				const lines = await executeExtensionCommand("agent.list_available_models", command.provider ?? "");
+				return success(id, "agent.list_available_models", {
+					models: parseAvailableModelLines(lines),
+				});
 			}
 
 			default: {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -576,6 +576,42 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 				return success(id, "get_commands", { commands });
 			}
 
+			// =================================================================
+			// Mesh / multi-agent IPC
+			// =================================================================
+
+			case "agent.discover": {
+				return success(id, "agent.discover", { agents: session.getDiscoveredAgents() });
+			}
+
+			case "agent.send": {
+				const response = await session.sendMeshFollowUp(command.targetSessionId, command.message);
+				if (!response.success) {
+					return error(id, "agent.send", response.error ?? "agent_send_failed");
+				}
+				return success(id, "agent.send", { response });
+			}
+
+			case "agent.steer": {
+				const response = await session.sendMeshSteer(command.targetSessionId, command.message);
+				if (!response.success) {
+					return error(id, "agent.steer", response.error ?? "agent_steer_failed");
+				}
+				return success(id, "agent.steer", { response });
+			}
+
+			case "agent.subscribe": {
+				const response = await session.sendMeshSubscribe(command.targetSessionId, command.topics);
+				if (!response.success) {
+					return error(id, "agent.subscribe", response.error ?? "agent_subscribe_failed");
+				}
+				return success(id, "agent.subscribe", { response });
+			}
+
+			case "session.mesh.status": {
+				return success(id, "session.mesh.status", session.getMeshStatus());
+			}
+
 			default: {
 				const unknownCommand = command as { type: string };
 				return error(undefined, unknownCommand.type, `Unknown command: ${unknownCommand.type}`);

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -7,6 +7,7 @@
 
 import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ImageContent, Model } from "@mariozechner/pi-ai";
+import type { AgentDiscoveryRecord, IpcResponse } from "@mariozechner/pi-ipc";
 import type { SessionStats } from "../../core/agent-session.js";
 import type { BashResult } from "../../core/bash-executor.js";
 import type { CompactionResult } from "../../core/compaction/index.js";
@@ -64,7 +65,14 @@ export type RpcCommand =
 	| { id?: string; type: "get_messages" }
 
 	// Commands (available for invocation via prompt)
-	| { id?: string; type: "get_commands" };
+	| { id?: string; type: "get_commands" }
+
+	// Mesh / multi-agent IPC
+	| { id?: string; type: "agent.discover" }
+	| { id?: string; type: "agent.send"; targetSessionId: string; message: string }
+	| { id?: string; type: "agent.steer"; targetSessionId: string; message: string }
+	| { id?: string; type: "agent.subscribe"; targetSessionId: string; topics: string[] }
+	| { id?: string; type: "session.mesh.status" };
 
 // ============================================================================
 // RPC Slash Command (for get_commands response)
@@ -199,6 +207,43 @@ export type RpcResponse =
 			command: "get_commands";
 			success: true;
 			data: { commands: RpcSlashCommand[] };
+	  }
+
+	// Mesh / multi-agent IPC
+	| {
+			id?: string;
+			type: "response";
+			command: "agent.discover";
+			success: true;
+			data: { agents: AgentDiscoveryRecord[] };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "agent.send";
+			success: true;
+			data: { response: IpcResponse };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "agent.steer";
+			success: true;
+			data: { response: IpcResponse };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "agent.subscribe";
+			success: true;
+			data: { response: IpcResponse };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "session.mesh.status";
+			success: true;
+			data: { enabled: boolean; running: boolean; sessionId: string; socketPath?: string; aliveAgents: number };
 	  }
 
 	// Error response (any command can fail)

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -72,7 +72,27 @@ export type RpcCommand =
 	| { id?: string; type: "agent.send"; targetSessionId: string; message: string }
 	| { id?: string; type: "agent.steer"; targetSessionId: string; message: string }
 	| { id?: string; type: "agent.subscribe"; targetSessionId: string; topics: string[] }
-	| { id?: string; type: "session.mesh.status" };
+	| { id?: string; type: "session.mesh.status" }
+
+	// Agent model routing controls
+	| { id?: string; type: "agent.list_models" }
+	| { id?: string; type: "agent.get_model"; agentName: string; category?: string }
+	| {
+			id?: string;
+			type: "agent.set_model";
+			agentName: string;
+			model: string;
+			thinkingLevel?: ThinkingLevel;
+	  }
+	| {
+			id?: string;
+			type: "agent.set_provider";
+			agentName: string;
+			provider: string;
+			thinkingLevel?: ThinkingLevel;
+	  }
+	| { id?: string; type: "agent.reset_model"; agentName: string }
+	| { id?: string; type: "agent.list_available_models"; provider?: string };
 
 // ============================================================================
 // RPC Slash Command (for get_commands response)
@@ -109,6 +129,15 @@ export interface RpcSessionState {
 	autoCompactionEnabled: boolean;
 	messageCount: number;
 	pendingMessageCount: number;
+}
+
+export interface RpcResolvedAgentModel {
+	agentName: string;
+	modelId?: string;
+	provider?: string;
+	thinkingLevel?: ThinkingLevel;
+	resolvedVia?: string;
+	error?: string;
 }
 
 // ============================================================================
@@ -244,6 +273,50 @@ export type RpcResponse =
 			command: "session.mesh.status";
 			success: true;
 			data: { enabled: boolean; running: boolean; sessionId: string; socketPath?: string; aliveAgents: number };
+	  }
+
+	// Agent model routing controls
+	| {
+			id?: string;
+			type: "response";
+			command: "agent.list_models";
+			success: true;
+			data: { agents: RpcResolvedAgentModel[] };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "agent.get_model";
+			success: true;
+			data: { resolved: RpcResolvedAgentModel };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "agent.set_model";
+			success: true;
+			data: { resolved: RpcResolvedAgentModel };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "agent.set_provider";
+			success: true;
+			data: { resolved: RpcResolvedAgentModel };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "agent.reset_model";
+			success: true;
+			data: { resolved: RpcResolvedAgentModel };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "agent.list_available_models";
+			success: true;
+			data: { models: Array<{ provider: string; modelId: string }> };
 	  }
 
 	// Error response (any command can fail)

--- a/packages/coding-agent/test/rpc-mode-agent-models.test.ts
+++ b/packages/coding-agent/test/rpc-mode-agent-models.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import { parseAvailableModelLines, parseResolvedAgentModelLine } from "../src/modes/rpc/rpc-mode.js";
+
+describe("rpc-mode multi-agent model parsing", () => {
+	test("parses resolved agent model lines", () => {
+		const parsed = parseResolvedAgentModelLine(
+			"oracle -> anthropic/claude-opus-4-6 via agent_model_direct thinking=high",
+		);
+		expect(parsed).toEqual({
+			agentName: "oracle",
+			modelId: "anthropic/claude-opus-4-6",
+			provider: "anthropic",
+			resolvedVia: "agent_model_direct",
+			thinkingLevel: "high",
+		});
+	});
+
+	test("parses unresolved agent model lines", () => {
+		const parsed = parseResolvedAgentModelLine("explore -> unresolved (Agent is disabled: explore)");
+		expect(parsed).toEqual({
+			agentName: "explore",
+			error: "Agent is disabled: explore",
+		});
+	});
+
+	test("parses available model list output", () => {
+		const parsed = parseAvailableModelLines([
+			"anthropic/claude-opus-4-6",
+			"google/gemini-2.5-pro",
+			"No models available for provider custom.",
+		]);
+		expect(parsed).toEqual([
+			{ provider: "anthropic", modelId: "claude-opus-4-6" },
+			{ provider: "google", modelId: "gemini-2.5-pro" },
+		]);
+	});
+});

--- a/packages/ipc/CHANGELOG.md
+++ b/packages/ipc/CHANGELOG.md
@@ -5,3 +5,4 @@
 ### Added
 
 - Added initial IPC package scaffold with socket server/client, broker routing, discovery, shared-state storage, and token auth utilities.
+- Added optional server-published discovery metadata (`.sock.json`) and runtime metadata updates for mesh-aware routing.

--- a/packages/ipc/README.md
+++ b/packages/ipc/README.md
@@ -7,7 +7,7 @@ IPC transport primitives for pi multi-agent orchestration.
 - `AgentIpcServer`: Unix domain socket JSON-RPC server.
 - `AgentIpcClient`: reconnecting client with request/response correlation.
 - `AgentIpcBroker`: in-process message router and pub/sub registry.
-- `AgentDiscovery`: socket directory discovery helpers.
+- `AgentDiscovery`: socket directory discovery helpers (+ optional `.sock.json` metadata).
 - `SharedStateManager`: namespaced file-backed shared state.
 - `IpcAuthManager`: HMAC token generation/verification for session messages.
 
@@ -18,6 +18,8 @@ import { AgentIpcServer, createIpcMessage } from "@mariozechner/pi-ipc";
 
 const server = new AgentIpcServer({
 	sessionId: "ses_demo",
+	agentName: "sisyphus",
+	currentModel: "anthropic/claude-opus-4-6",
 	onMessage: async (message) => {
 		if (message.type === "session.steer") {
 			return { success: true, data: { accepted: true } };

--- a/packages/ipc/src/server.ts
+++ b/packages/ipc/src/server.ts
@@ -1,8 +1,8 @@
-import { chmodSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { basename, dirname, join } from "node:path";
 import { createIpcResponse } from "./messages.js";
-import type { IpcInboundMessage, IpcMessage, IpcRequestHandler, IpcResponse } from "./types.js";
+import type { AgentDiscoveryRecord, IpcInboundMessage, IpcMessage, IpcRequestHandler, IpcResponse } from "./types.js";
 
 export interface AgentIpcServerOptions {
 	sessionId: string;
@@ -10,6 +10,11 @@ export interface AgentIpcServerOptions {
 	socketDir?: string;
 	socketPath?: string;
 	onClientMessage?: (message: IpcMessage) => void;
+	agentName?: string;
+	status?: "idle" | "running" | "busy";
+	capabilities?: string[];
+	currentModel?: string;
+	parentSessionId?: string;
 }
 
 function defaultSocketDir(): string {
@@ -42,6 +47,7 @@ export class AgentIpcServer {
 
 	private readonly onMessage: IpcRequestHandler;
 	private readonly onClientMessage?: (message: IpcMessage) => void;
+	private readonly metadata: Omit<AgentDiscoveryRecord, "sessionId" | "socketPath" | "updatedAt">;
 	private readonly sockets = new Set<Socket>();
 	private server?: Server;
 
@@ -50,6 +56,13 @@ export class AgentIpcServer {
 		this.socketPath = options.socketPath ?? deriveSocketPath(options.sessionId, options.socketDir);
 		this.onMessage = options.onMessage;
 		this.onClientMessage = options.onClientMessage;
+		this.metadata = {
+			agentName: options.agentName,
+			status: options.status,
+			capabilities: options.capabilities,
+			currentModel: options.currentModel,
+			parentSessionId: options.parentSessionId,
+		};
 	}
 
 	async start(): Promise<void> {
@@ -72,6 +85,7 @@ export class AgentIpcServer {
 			this.server?.listen(this.socketPath, () => resolve());
 		});
 		chmodSync(this.socketPath, 0o600);
+		this.writeMetadata();
 	}
 
 	private handleConnection(socket: Socket): void {
@@ -156,6 +170,10 @@ export class AgentIpcServer {
 		if (existsSync(this.socketPath)) {
 			rmSync(this.socketPath, { force: true });
 		}
+		const metadataPath = this.getMetadataPath();
+		if (existsSync(metadataPath)) {
+			rmSync(metadataPath, { force: true });
+		}
 	}
 
 	broadcast(message: IpcMessage): void {
@@ -178,6 +196,26 @@ export class AgentIpcServer {
 			socketName: basename(this.socketPath),
 			clientCount: this.sockets.size,
 		};
+	}
+
+	updateMetadata(metadata: Partial<Omit<AgentDiscoveryRecord, "sessionId" | "socketPath" | "updatedAt">>): void {
+		Object.assign(this.metadata, metadata);
+		if (this.isRunning()) {
+			this.writeMetadata();
+		}
+	}
+
+	private getMetadataPath(): string {
+		return `${this.socketPath}.json`;
+	}
+
+	private writeMetadata(): void {
+		const payload = {
+			...this.metadata,
+			sessionId: this.sessionId,
+			socketPath: this.socketPath,
+		};
+		writeFileSync(this.getMetadataPath(), JSON.stringify(payload, null, "\t"));
 	}
 }
 

--- a/packages/ipc/test/discovery.test.ts
+++ b/packages/ipc/test/discovery.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 import { AgentDiscovery } from "../src/discovery.js";
+import { AgentIpcServer } from "../src/server.js";
 
 const cleanupPaths: string[] = [];
 
@@ -31,5 +32,33 @@ describe("AgentDiscovery", () => {
 		expect(records[0].sessionId).toBe("ses_alpha");
 		expect(records[0].agentName).toBe("oracle");
 		expect(discovery.getSocketPath("ses_alpha")).toContain("ses_alpha.sock");
+	});
+
+	test("reads metadata written by AgentIpcServer", async () => {
+		const socketDir = mkdtempSync(join(tmpdir(), "pi-discovery-server-"));
+		cleanupPaths.push(socketDir);
+
+		const server = new AgentIpcServer({
+			sessionId: "ses_server",
+			socketDir,
+			agentName: "oracle",
+			status: "idle",
+			currentModel: "anthropic/claude-opus-4-6",
+			onMessage: async () => ({ success: true }),
+		});
+		await server.start();
+
+		const discovery = new AgentDiscovery({ socketDir });
+		const record = discovery.findBySessionId("ses_server");
+		expect(record?.agentName).toBe("oracle");
+		expect(record?.status).toBe("idle");
+		expect(record?.currentModel).toBe("anthropic/claude-opus-4-6");
+
+		server.updateMetadata({ status: "running" });
+		const updated = discovery.findBySessionId("ses_server");
+		expect(updated?.status).toBe("running");
+
+		await server.stop();
+		expect(discovery.findBySessionId("ses_server")).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary
Follow-up slice for issue #14 canonical docs (continuing after merged PR #15).

This PR advances Phase-2 IPC mesh + RPC integration:
- remote `task.delegate` routing across discovered sessions
- IPC mesh command surface
- full `agent.*` RPC model-routing command coverage (including runtime set/reset)

## Canonical-doc checklist (completed in this PR)

### Phase 2
- [x] IPC discovery metadata lifecycle on socket files (`.sock.json`) including model updates
- [x] Remote delegation path in `TaskDelegator` via IPC (`task.delegate`)
- [x] `AgentSession` IPC handling for `task.delegate` and `task.result` broadcast
- [x] Mesh command support in extension (`/agent.discover`, `/agent.send`, `/agent.steer`, `/agent.subscribe`, `/session.mesh.status`)
- [x] Added additional built-in agents from roadmap (`hephaestus`, `librarian`, `metis`, `prometheus`)
- [x] RPC transport wiring for mesh commands:
  - [x] `agent.discover`
  - [x] `agent.send`
  - [x] `agent.steer`
  - [x] `agent.subscribe`
  - [x] `session.mesh.status`
- [x] RPC transport wiring for model-routing commands from DOC-B:
  - [x] `agent.list_models`
  - [x] `agent.get_model`
  - [x] `agent.set_model`
  - [x] `agent.set_provider`
  - [x] `agent.reset_model`
  - [x] `agent.list_available_models`
- [x] Added parsing/unit tests for RPC model-routing command output
- [x] Updated multi-agent README with slash/RPC command coverage

## Canonical-doc checklist (pending for full acceptance)

### Remaining Phase 2
- [ ] Atlas orchestration workflow (`OrchestratorAgent` / Todo + QA-gate semantics) from DOC-A
- [ ] Full shared-state lock protocol hardening + richer broker/pub-sub integration semantics
- [ ] End-to-end integration tests for cross-process parallel orchestration scenarios

### Phase 3
- [ ] TUI multi-agent panel + mesh visualization/progress UX
- [ ] Security hardening (strict session-token handshake enforcement, IPC rate limiting)
- [ ] Observability/metrics/export enhancements
- [ ] Hashline Edit coexistence path/package
- [ ] Production migration guide completion against DOC-A/DOC-B matrix

## Validation
- `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/rpc-mode-agent-models.test.ts`
- `cd extensions/multi-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/model-router.test.ts test/task-delegator.test.ts`
- `npx tsgo -p packages/coding-agent/tsconfig.build.json`
- `npm run check`

## Notes
- PR #15 delivered Phase-1 baseline.
- This PR continues from that baseline with additional Phase-2 slices.
